### PR TITLE
Running alpha QED

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,15 +11,15 @@ target_compile_options(
 	$<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -pedantic>
 	$<$<CXX_COMPILER_ID:MSVC>:/W4>)
 
-add_executable(alpha alpha.cpp)
-target_link_libraries(alpha PRIVATE sidis)
-target_compile_features(alpha PRIVATE cxx_std_11)
+add_executable(alpha_qed alpha_qed.cpp)
+target_link_libraries(alpha_qed PRIVATE sidis)
+target_compile_features(alpha_qed PRIVATE cxx_std_11)
 set_target_properties(
-	alpha PROPERTIES
+	alpha_qed PROPERTIES
 	CXX_EXTENSIONS OFF
 	INTERPROCEDURAL_OPTIMIZATION ${Sidis_IPO_ENABLED})
 target_compile_options(
-	alpha
+	alpha_qed
 	PRIVATE
 	$<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -pedantic>
 	$<$<CXX_COMPILER_ID:MSVC>:/W4>)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,6 +11,19 @@ target_compile_options(
 	$<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -pedantic>
 	$<$<CXX_COMPILER_ID:MSVC>:/W4>)
 
+add_executable(alpha alpha.cpp)
+target_link_libraries(alpha PRIVATE sidis)
+target_compile_features(alpha PRIVATE cxx_std_11)
+set_target_properties(
+	alpha PROPERTIES
+	CXX_EXTENSIONS OFF
+	INTERPROCEDURAL_OPTIMIZATION ${Sidis_IPO_ENABLED})
+target_compile_options(
+	alpha
+	PRIVATE
+	$<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -pedantic>
+	$<$<CXX_COMPILER_ID:MSVC>:/W4>)
+
 add_executable(random_phase_space random_phase_space.cpp)
 target_link_libraries(random_phase_space PRIVATE sidis)
 target_compile_features(random_phase_space PRIVATE cxx_std_11)

--- a/example/alpha.cpp
+++ b/example/alpha.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include <sidis/sidis.hpp>
+
+// Compute the QED coupling constant at a certain value of Q^2.
+int main(int argc, char** argv) {
+	if (argc != 2) {
+		std::cerr << "Usage: alpha <Q sq. (GeV)>" << std::endl;
+		return 1;
+	}
+	sidis::Real Q_sq = std::stold(argv[1]);
+	std::cout << "α = " << sidis::alpha(Q_sq) << std::endl;
+	return 0;
+}
+

--- a/example/alpha_qed.cpp
+++ b/example/alpha_qed.cpp
@@ -5,11 +5,11 @@
 // Compute the QED coupling constant at a certain value of Q^2.
 int main(int argc, char** argv) {
 	if (argc != 2) {
-		std::cerr << "Usage: alpha <Q sq. (GeV)>" << std::endl;
+		std::cerr << "Usage: alpha_qed <Q sq. (GeV)>" << std::endl;
 		return 1;
 	}
 	sidis::Real Q_sq = std::stold(argv[1]);
-	std::cout << "α = " << sidis::alpha(Q_sq) << std::endl;
+	std::cout << "α = " << sidis::alpha_qed(Q_sq) << std::endl;
 	return 0;
 }
 

--- a/include/sidis/constant.hpp
+++ b/include/sidis/constant.hpp
@@ -20,9 +20,9 @@ static Real const SQRT_2 = 1.414213562373095048801688724209698078569671875376948
 extern Real const INF;
 
 /// QED coupling constant at electron mass.
-static Real const ALPHA_0 = 1.L / 137.03599L;
-/// Calculates the fine structure constant at a certain Q^2 value.
-Real alpha(Real Q_sq=0.);
+static Real const ALPHA_QED_0 = 1.L / 137.03599L;
+/// Calculates the QED coupling constant at a certain Q^2 value.
+Real alpha_qed(Real Q_sq=0.);
 
 /// \name Particle masses
 /// \sa ParticleGroup

--- a/include/sidis/constant.hpp
+++ b/include/sidis/constant.hpp
@@ -19,8 +19,10 @@ static Real const SQRT_2 = 1.414213562373095048801688724209698078569671875376948
 /// Positive infinity.
 extern Real const INF;
 
-/// Fine structure constant.
-static Real const ALPHA = 7.2973525664e-3L;
+/// QED coupling constant at electron mass.
+static Real const ALPHA_0 = 1.L / 137.03599L;
+/// Calculates the fine structure constant at a certain Q^2 value.
+Real alpha(Real Q_sq=0.);
 
 /// \name Particle masses
 /// \sa ParticleGroup

--- a/include/sidis/cross_section.hpp
+++ b/include/sidis/cross_section.hpp
@@ -200,7 +200,7 @@ Real delta_vac_had(kin::Kinematics const& kin);
 
 struct Born {
 	Real coeff;
-	explicit Born(kin::Kinematics const& kin);
+	Born(kin::Kinematics const& kin, Real alpha);
 };
 
 Real born_uu_base(Born const& b, lep::LepBornUU const& lep, had::HadUU const& had);
@@ -226,7 +226,7 @@ math::Vec3 born_lp_base(Born const& b, lep::LepBornLX const& lep, had::HadLP con
 
 struct Amm {
 	Real coeff;
-	explicit Amm(kin::Kinematics const& kin);
+	Amm(kin::Kinematics const& kin, Real alpha);
 };
 
 Real amm_uu_base(Amm const& b, lep::LepAmmUU const& lep, had::HadUU const& had);
@@ -255,7 +255,7 @@ math::Vec3 amm_lp_base(Amm const& b, lep::LepAmmLX const& lep, had::HadLP const&
 struct Nrad {
 	Real coeff_born;
 	Real coeff_amm;
-	explicit Nrad(kin::Kinematics const& kin, Real k_0_bar);
+	Nrad(kin::Kinematics const& kin, Real k_0_bar, Real alpha);
 };
 
 Real nrad_ir_uu_base(Nrad const& b, lep::LepNradUU const& lep, had::HadUU const& had);
@@ -285,7 +285,7 @@ math::Vec3 nrad_ir_lp_base(Nrad const& b, lep::LepNradLX const& lep, had::HadLP 
 struct Rad {
 	Real coeff;
 	Real R;
-	explicit Rad(kin::KinematicsRad const& kin);
+	Rad(kin::KinematicsRad const& kin, Real alpha);
 };
 
 Real rad_uu_base(Rad const& b, lep::LepRadUU const& lep, had::HadRadUU const& had);

--- a/src/asymmetry.cpp
+++ b/src/asymmetry.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "sidis/constant.hpp"
 #include "sidis/cross_section.hpp"
 #include "sidis/cut.hpp"
 #include "sidis/hadronic_coeff.hpp"
@@ -31,12 +32,13 @@ EstErr ut_integ_h(
 		IntegParams params) {
 	Real Q_sq = S * x * y;
 	sf::SfUP sf = sf_set.sf_up(ps.hadron, x, z, Q_sq, ph_t_sq);
+	Real alpha = alpha_qed(Q_sq);
 	if (!include_rc) {
 		EstErr born_integ = integrate(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Born b(kin);
+				xs::Born b(kin, alpha);
 				lep::LepBornUX lep(kin);
 				had::HadUP had(kin, sf);
 				Vec3 eta(
@@ -59,7 +61,7 @@ EstErr ut_integ_h(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Nrad b(kin, INF);
+				xs::Nrad b(kin, INF, alpha);
 				lep::LepNradUX lep(kin);
 				had::HadUP had(kin, sf);
 				Vec3 eta(
@@ -86,7 +88,7 @@ EstErr ut_integ_h(
 				}
 				jacobian *= phi_h_b.size();
 
-				xs::Rad b(kin_rad);
+				xs::Rad b(kin_rad, alpha);
 				sf::SfUP shift_sf = sf_set.sf_up(
 					ps.hadron,
 					kin_rad.shift_x, kin_rad.shift_z, kin_rad.shift_Q_sq, kin_rad.shift_ph_t_sq);
@@ -125,13 +127,14 @@ EstErr asym::uu_integ(
 	// Calculate the structure functions ahead of time, because they are
 	// constant over the integrals we'll be doing.
 	sf::SfUU sf = sf_set.sf_uu(ps.hadron, x, z, Q_sq, ph_t_sq);
+	Real alpha = alpha_qed(Q_sq);
 	if (!include_rc) {
 		// Without radiative corrections, there is only the Born cross-section.
 		EstErr born_integ = integrate(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Born born(kin);
+				xs::Born born(kin, alpha);
 				lep::LepBornUU lep(kin);
 				had::HadUU had(kin, sf);
 				return xs::born_uu_base(born, lep, had);
@@ -149,7 +152,7 @@ EstErr asym::uu_integ(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Nrad b(kin, INF);
+				xs::Nrad b(kin, INF, alpha);
 				lep::LepNradUU lep(kin);
 				had::HadUU had(kin, sf);
 				return xs::nrad_ir_uu_base(b, lep, had);
@@ -171,7 +174,7 @@ EstErr asym::uu_integ(
 				}
 				jacobian *= phi_h_b.size();
 
-				xs::Rad b(kin_rad);
+				xs::Rad b(kin_rad, alpha);
 				sf::SfUU shift_sf = sf_set.sf_uu(
 					ps.hadron,
 					kin_rad.shift_x, kin_rad.shift_z, kin_rad.shift_Q_sq, kin_rad.shift_ph_t_sq);

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -14,14 +14,14 @@ Real const Q_SQ_MAX = 100.;
 Real const NF = 1.;
 Real const BETA_0 = 4. / 3. * NF;
 
-Real beta(Real alpha) {
+Real beta_qed(Real alpha) {
 	Real alpha_r = alpha / (4. * PI);
 	return 4. * PI * BETA_0 * (1. + 3. * alpha_r) * alpha_r * alpha_r;
 }
 
-interp::Grid<Real, 1> create_alpha_grid(Real Q_sq_max) {
+interp::Grid<Real, 1> create_alpha_qed_grid(Real Q_sq_max) {
 	std::vector<Real> ln_Q_sq_vals { 2. * std::log(MASS_E) };
-	std::vector<Real> alpha_vals { ALPHA_0 };
+	std::vector<Real> alpha_vals { ALPHA_QED_0 };
 	// Generate points until a couple of points after max Q^2 is reached, to
 	// ensure that cubic interpolation will work well until the end.
 	std::size_t extra = 8;
@@ -32,10 +32,10 @@ interp::Grid<Real, 1> create_alpha_grid(Real Q_sq_max) {
 		Real ln_Q_sq_0 = ln_Q_sq_vals.back();
 		Real ln_Q_sq_1 = ln_Q_sq_0 + step;
 		Real alpha_0 = alpha_vals.back();
-		Real alpha_p1 = beta(alpha_0);
-		Real alpha_p2 = beta(alpha_0 + 0.5 * step * alpha_p1);
-		Real alpha_p3 = beta(alpha_0 + 0.5 * step * alpha_p2);
-		Real alpha_p4 = beta(alpha_0 + step * alpha_p3);
+		Real alpha_p1 = beta_qed(alpha_0);
+		Real alpha_p2 = beta_qed(alpha_0 + 0.5 * step * alpha_p1);
+		Real alpha_p3 = beta_qed(alpha_0 + 0.5 * step * alpha_p2);
+		Real alpha_p4 = beta_qed(alpha_0 + step * alpha_p3);
 		Real alpha_1 = alpha_0
 			+ step * (alpha_p1 + 2. * alpha_p2 + 2. * alpha_p3 + alpha_p4) / 6.;
 		alpha_vals.push_back(alpha_1);
@@ -46,12 +46,12 @@ interp::Grid<Real, 1> create_alpha_grid(Real Q_sq_max) {
 		{ ln_Q_sq_vals.size() }, { ln_Q_sq_vals.front() }, { ln_Q_sq_vals.back() });
 }
 
-interp::Grid<Real, 1> const alpha_grid = create_alpha_grid(Q_SQ_MAX);
+interp::Grid<Real, 1> const alpha_qed_grid = create_alpha_qed_grid(Q_SQ_MAX);
 
 }
 
-Real sidis::alpha(Real Q_sq) {
-	auto cubic_view = interp::CubicView<Real, 1>(alpha_grid);
+Real sidis::alpha_qed(Real Q_sq) {
+	auto cubic_view = interp::CubicView<Real, 1>(alpha_qed_grid);
 	if (Q_sq < Q_SQ_MAX) {
 		// Note that if Q^2 is smaller than the electron mass, this will NaN.
 		// Since this is well out of the DIS regime, this isn't a problem.

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -2,7 +2,66 @@
 
 #include <limits>
 
+#include "sidis/extra/interpolate.hpp"
+
 using namespace sidis;
 
 Real const sidis::INF = std::numeric_limits<Real>::infinity();
+
+namespace {
+
+Real const Q_SQ_MAX = 100.;
+Real const NF = 1.;
+Real const BETA_0 = 4. / 3. * NF;
+
+Real beta(Real alpha) {
+	Real alpha_r = alpha / (4. * PI);
+	return 4. * PI * BETA_0 * (1. + 3. * alpha_r) * alpha_r * alpha_r;
+}
+
+interp::Grid<Real, 1> create_alpha_grid(Real Q_sq_max) {
+	std::vector<Real> ln_Q_sq_vals { 2. * std::log(MASS_E) };
+	std::vector<Real> alpha_vals { ALPHA_0 };
+	// Generate points until a couple of points after max Q^2 is reached, to
+	// ensure that cubic interpolation will work well until the end.
+	std::size_t extra = 8;
+	while (ln_Q_sq_vals.size() < extra
+			|| ln_Q_sq_vals[ln_Q_sq_vals.size() - extra] <= std::log(Q_sq_max)) {
+		// RK4 evolution.
+		Real step = 0.01;
+		Real ln_Q_sq_0 = ln_Q_sq_vals.back();
+		Real ln_Q_sq_1 = ln_Q_sq_0 + step;
+		Real alpha_0 = alpha_vals.back();
+		Real alpha_p1 = beta(alpha_0);
+		Real alpha_p2 = beta(alpha_0 + 0.5 * step * alpha_p1);
+		Real alpha_p3 = beta(alpha_0 + 0.5 * step * alpha_p2);
+		Real alpha_p4 = beta(alpha_0 + step * alpha_p3);
+		Real alpha_1 = alpha_0
+			+ step * (alpha_p1 + 2. * alpha_p2 + 2. * alpha_p3 + alpha_p4) / 6.;
+		alpha_vals.push_back(alpha_1);
+		ln_Q_sq_vals.push_back(ln_Q_sq_1);
+	}
+	return interp::Grid<Real, 1>(
+		alpha_vals.data(),
+		{ ln_Q_sq_vals.size() }, { ln_Q_sq_vals.front() }, { ln_Q_sq_vals.back() });
+}
+
+interp::Grid<Real, 1> const alpha_grid = create_alpha_grid(Q_SQ_MAX);
+
+}
+
+Real sidis::alpha(Real Q_sq) {
+	auto cubic_view = interp::CubicView<Real, 1>(alpha_grid);
+	if (Q_sq < Q_SQ_MAX) {
+		// Note that if Q^2 is smaller than the electron mass, this will NaN.
+		// Since this is well out of the DIS regime, this isn't a problem.
+		return cubic_view({ std::log(Q_sq) });
+	} else {
+		// Use analytic expression to continue past the end of the grid. This is
+		// the one-loop result.
+		Real alpha_r_max = cubic_view({ std::log(Q_SQ_MAX) }) / (4. * PI);
+		return 4. * PI * alpha_r_max
+			/ (1. - alpha_r_max * BETA_0 * std::log(Q_sq / Q_SQ_MAX));
+	}
+}
 

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -326,18 +326,18 @@ Real xs::delta_vac_lep(Kinematics const& kin) {
 
 Real xs::delta_vac_had(Kinematics const& kin) {
 	if (kin.Q_sq < 1.) {
-		return -(2.*PI)/ALPHA*(-1.345e-9L - 2.302e-3L*std::log(1. + 4.091L*kin.Q_sq));
+		return -(2.*PI)/alpha(kin.Q_sq)*(-1.345e-9L - 2.302e-3L*std::log(1. + 4.091L*kin.Q_sq));
 	} else if (kin.Q_sq < 64.) {
-		return -(2.*PI)/ALPHA*(-1.512e-3L - 2.822e-3L*std::log(1. + 1.218L*kin.Q_sq));
+		return -(2.*PI)/alpha(kin.Q_sq)*(-1.512e-3L - 2.822e-3L*std::log(1. + 1.218L*kin.Q_sq));
 	} else {
-		return -(2.*PI)/ALPHA*(-1.1344e-3L - 3.0680e-3L*std::log(1. + 0.99992L*kin.Q_sq));
+		return -(2.*PI)/alpha(kin.Q_sq)*(-1.1344e-3L - 3.0680e-3L*std::log(1. + 0.99992L*kin.Q_sq));
 	}
 }
 
 // Born base functions.
 Born::Born(Kinematics const& kin) :
 	// Equation [1.15]. The `Q^4` factor has been absorbed into `C_1`.
-	coeff((sq(ALPHA)*kin.S*sq(kin.S_x))/(8.*kin.M*kin.ph_l*kin.lambda_S)) { }
+	coeff((sq(alpha(kin.Q_sq))*kin.S*sq(kin.S_x))/(8.*kin.M*kin.ph_l*kin.lambda_S)) { }
 
 Real xs::born_uu_base(Born const& b, LepBornUU const& lep, HadUU const& had) {
 	return b.coeff*(
@@ -392,7 +392,7 @@ Amm::Amm(Kinematics const& kin) {
 	Real diff_m = sqrt1p_1m((4.*sq(kin.m))/kin.Q_sq);
 	Real sum_m = 2. + diff_m;
 	Real L_m = 1./lambda_m_sqrt*std::log(sum_m/diff_m);
-	coeff = L_m*kin.Q_sq*(std::pow(ALPHA, 3)*sq(kin.m)*kin.S*sq(kin.S_x))
+	coeff = L_m*kin.Q_sq*(std::pow(alpha(kin.Q_sq), 3)*sq(kin.m)*kin.S*sq(kin.S_x))
 		/(16.*PI*kin.M*kin.ph_l*kin.lambda_S);
 }
 
@@ -445,7 +445,7 @@ Vec3 xs::amm_lp_base(Amm const& b, LepAmmLX const& lep, HadLP const& had) {
 Nrad::Nrad(Kinematics const& kin, Real k_0_bar) {
 	Born born(kin);
 	Amm amm(kin);
-	Real born_factor = 1. + ALPHA/PI*(
+	Real born_factor = 1. + alpha(kin.Q_sq)/PI*(
 		delta_vert_rad_ir(kin, k_0_bar)
 		+ delta_vac_lep(kin)
 		+ delta_vac_had(kin));
@@ -509,7 +509,7 @@ Vec3 xs::nrad_ir_lp_base(Nrad const& b, LepNradLX const& lep, HadLP const& had) 
 // Radiative base functions.
 Rad::Rad(KinematicsRad const& kin) {
 	// Equation [1.43].
-	coeff = -(std::pow(ALPHA, 3)*kin.S*sq(kin.S_x))
+	coeff = -(std::pow(alpha(kin.Q_sq), 3)*kin.S*sq(kin.S_x))
 		/(64.*sq(PI)*kin.M*kin.ph_l*kin.lambda_S*kin.lambda_Y_sqrt);
 	R = kin.R;
 }

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -326,18 +326,21 @@ Real xs::delta_vac_lep(Kinematics const& kin) {
 
 Real xs::delta_vac_had(Kinematics const& kin) {
 	if (kin.Q_sq < 1.) {
-		return -(2.*PI)/alpha(kin.Q_sq)*(-1.345e-9L - 2.302e-3L*std::log(1. + 4.091L*kin.Q_sq));
+		return -(2.*PI)/alpha_qed(kin.Q_sq)
+			*(-1.345e-9L - 2.302e-3L*std::log(1. + 4.091L*kin.Q_sq));
 	} else if (kin.Q_sq < 64.) {
-		return -(2.*PI)/alpha(kin.Q_sq)*(-1.512e-3L - 2.822e-3L*std::log(1. + 1.218L*kin.Q_sq));
+		return -(2.*PI)/alpha_qed(kin.Q_sq)
+			*(-1.512e-3L - 2.822e-3L*std::log(1. + 1.218L*kin.Q_sq));
 	} else {
-		return -(2.*PI)/alpha(kin.Q_sq)*(-1.1344e-3L - 3.0680e-3L*std::log(1. + 0.99992L*kin.Q_sq));
+		return -(2.*PI)/alpha_qed(kin.Q_sq)
+			*(-1.1344e-3L - 3.0680e-3L*std::log(1. + 0.99992L*kin.Q_sq));
 	}
 }
 
 // Born base functions.
 Born::Born(Kinematics const& kin) :
 	// Equation [1.15]. The `Q^4` factor has been absorbed into `C_1`.
-	coeff((sq(alpha(kin.Q_sq))*kin.S*sq(kin.S_x))/(8.*kin.M*kin.ph_l*kin.lambda_S)) { }
+	coeff((sq(alpha_qed(kin.Q_sq))*kin.S*sq(kin.S_x))/(8.*kin.M*kin.ph_l*kin.lambda_S)) { }
 
 Real xs::born_uu_base(Born const& b, LepBornUU const& lep, HadUU const& had) {
 	return b.coeff*(
@@ -392,7 +395,8 @@ Amm::Amm(Kinematics const& kin) {
 	Real diff_m = sqrt1p_1m((4.*sq(kin.m))/kin.Q_sq);
 	Real sum_m = 2. + diff_m;
 	Real L_m = 1./lambda_m_sqrt*std::log(sum_m/diff_m);
-	coeff = L_m*kin.Q_sq*(std::pow(alpha(kin.Q_sq), 3)*sq(kin.m)*kin.S*sq(kin.S_x))
+	coeff = L_m*kin.Q_sq*(std::pow(alpha_qed(kin.Q_sq), 3)
+		*sq(kin.m)*kin.S*sq(kin.S_x))
 		/(16.*PI*kin.M*kin.ph_l*kin.lambda_S);
 }
 
@@ -445,7 +449,7 @@ Vec3 xs::amm_lp_base(Amm const& b, LepAmmLX const& lep, HadLP const& had) {
 Nrad::Nrad(Kinematics const& kin, Real k_0_bar) {
 	Born born(kin);
 	Amm amm(kin);
-	Real born_factor = 1. + alpha(kin.Q_sq)/PI*(
+	Real born_factor = 1. + alpha_qed(kin.Q_sq)/PI*(
 		delta_vert_rad_ir(kin, k_0_bar)
 		+ delta_vac_lep(kin)
 		+ delta_vac_had(kin));
@@ -509,7 +513,7 @@ Vec3 xs::nrad_ir_lp_base(Nrad const& b, LepNradLX const& lep, HadLP const& had) 
 // Radiative base functions.
 Rad::Rad(KinematicsRad const& kin) {
 	// Equation [1.43].
-	coeff = -(std::pow(alpha(kin.Q_sq), 3)*kin.S*sq(kin.S_x))
+	coeff = -(std::pow(alpha_qed(kin.Q_sq), 3)*kin.S*sq(kin.S_x))
 		/(64.*sq(PI)*kin.M*kin.ph_l*kin.lambda_S*kin.lambda_Y_sqrt);
 	R = kin.R;
 }


### PR DESCRIPTION
The QED coupling constant should change with Q. Here we use 2-loop beta function to evolve alpha from electron mass up to Q. The evolution results are cached on grids and looked up when needed. If alpha is greater than the maximum supported Q, then analytic one-loop beta function is used to extrapolate.

- [ ] Recalculate test cross section values with evolving alpha.