### PR TITLE
Merge support for phenomenological inputs

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,6 +10,18 @@ target_compile_options(
 	PRIVATE
 	${Sidis_COMPILER_WARNINGS})
 
+add_executable(alpha_qed alpha_qed.cpp)
+target_link_libraries(alpha_qed PRIVATE sidis)
+target_compile_features(alpha_qed PRIVATE cxx_std_11)
+set_target_properties(
+	alpha_qed PROPERTIES
+	CXX_EXTENSIONS OFF
+	INTERPROCEDURAL_OPTIMIZATION ${Sidis_IPO_ENABLED})
+target_compile_options(
+	alpha_qed
+	PRIVATE
+	${Sidis_COMPILER_WARNINGS})
+
 add_executable(random_phase_space random_phase_space.cpp)
 target_link_libraries(random_phase_space PRIVATE sidis)
 target_compile_features(random_phase_space PRIVATE cxx_std_11)

--- a/example/alpha_qed.cpp
+++ b/example/alpha_qed.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include <sidis/sidis.hpp>
+
+// Compute the QED coupling constant at a certain value of Q^2.
+int main(int argc, char** argv) {
+	if (argc != 2) {
+		std::cerr << "Usage: alpha_qed <Q² (GeV²)>" << std::endl;
+		return 1;
+	}
+	sidis::Real Q_sq = std::stold(argv[1]);
+	std::cout << "α = " << sidis::ph::alpha_qed(Q_sq) << std::endl;
+	return 0;
+}
+

--- a/include/sidis/constant.hpp
+++ b/include/sidis/constant.hpp
@@ -19,9 +19,6 @@ static Real const SQRT_2 = 1.414213562373095048801688724209698078569671875376948
 /// Positive infinity.
 extern Real const INF;
 
-/// Fine structure constant.
-static Real const ALPHA = 7.2973525664e-3L;
-
 /// \name Particle masses
 /// \sa ParticleGroup
 /// \{

--- a/include/sidis/cross_section.hpp
+++ b/include/sidis/cross_section.hpp
@@ -14,6 +14,9 @@ namespace kin {
 	struct Kinematics;
 	struct KinematicsRad;
 }
+namespace ph {
+	struct Phenom;
+}
 namespace lep {
 	struct LepBornUU;
 	struct LepBornUP;
@@ -133,37 +136,54 @@ math::IntegParams const DEFAULT_INTEG_PARAMS {
  * \defgroup GeneralXsGroup General cross-section functions
  * Functions for doing various kinds of cross-section calculations. They take a
  * kin::Kinematics, an sf::SfSet for structure functions, and the beam and
- * target polarizations.
+ * target polarizations. Additionally, a ph::Phenom object may (optionally) be
+ * provided, to use custom phenomenological inputs.
  * \ingroup XsGroup
  */
 /// \{
 
 /// %Born cross-section \f$\sigma_{B}\f$.
 Real born(kin::Kinematics const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
+/// \copydoc born()
+Real born(kin::Kinematics const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
 /// Anomalous magnetic moment cross-section \f$\sigma_{AMM}\f$, related to
 /// vertex correction diagram.
 Real amm(kin::Kinematics const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
+/// \copydoc amm()
+Real amm(kin::Kinematics const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
 /// Non-radiative cross-section neglecting infrared-divergent-free soft photon
 /// part \f$\sigma_{\text{nrad}}^{IR}\f$.
 Real nrad_ir(kin::Kinematics const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF);
+/// \copydoc nrad_ir()
+Real nrad_ir(kin::Kinematics const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF);
 /// Non-radiative cross-section \f$\sigma_{\text{nrad}}\f$, integrated over the
 /// radiated photon with energy below soft cutoff \p k_0_bar (if \p k_0_bar is
 /// set to infinity (default), then the entire radiative part is integrated
 /// over).
 math::EstErr nrad_integ(kin::Kinematics const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF, math::IntegParams params=DEFAULT_INTEG_PARAMS);
+/// \copydoc nrad_integ()
+math::EstErr nrad_integ(kin::Kinematics const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF, math::IntegParams params=DEFAULT_INTEG_PARAMS);
 /// Radiative cross-section with infrared divergence removed
 /// \f$\sigma_{R}^{F}\f$.
 Real rad_f(kin::KinematicsRad const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
+/// \copydoc rad_f()
+Real rad_f(kin::KinematicsRad const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
 /// Radiative cross-section \f$\sigma_{R}\f$.
 Real rad(kin::KinematicsRad const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
+/// \copydoc rad()
+Real rad(kin::KinematicsRad const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta);
 
 /// Radiative cross-section with infrared divergence removed
 /// \f$\sigma_{R}^{F}\f$, integrated over the radiated photon with energy below
 /// soft cutoff \p k_0_bar.
 math::EstErr rad_f_integ(kin::Kinematics const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF, math::IntegParams params=DEFAULT_INTEG_PARAMS);
+/// \copydoc rad_f_integ()
+math::EstErr rad_f_integ(kin::Kinematics const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF, math::IntegParams params=DEFAULT_INTEG_PARAMS);
 /// Radiative cross-section \f$\sigma_{R}\f$, integrated over the radiated
 /// photon with energy above soft cutoff \p k_0_bar.
 math::EstErr rad_integ(kin::Kinematics const& kin, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF, math::IntegParams params=DEFAULT_INTEG_PARAMS);
+/// \copydoc rad_integ()
+math::EstErr rad_integ(kin::Kinematics const& kin, ph::Phenom const& phenom, sf::SfSet const& sf, Real lambda_e, math::Vec3 eta, Real k_0_bar=INF, math::IntegParams params=DEFAULT_INTEG_PARAMS);
 /// \}
 
 /// \name Born correction factors
@@ -200,7 +220,7 @@ Real delta_vac_had(kin::Kinematics const& kin);
 
 struct Born {
 	Real coeff;
-	explicit Born(kin::Kinematics const& kin);
+	Born(kin::Kinematics const& kin, ph::Phenom const& phenom);
 };
 
 Real born_uu_base(Born const& b, lep::LepBornUU const& lep, had::HadUU const& had);
@@ -226,7 +246,7 @@ math::Vec3 born_lp_base(Born const& b, lep::LepBornLX const& lep, had::HadLP con
 
 struct Amm {
 	Real coeff;
-	explicit Amm(kin::Kinematics const& kin);
+	Amm(kin::Kinematics const& kin, ph::Phenom const& phenom);
 };
 
 Real amm_uu_base(Amm const& b, lep::LepAmmUU const& lep, had::HadUU const& had);
@@ -255,7 +275,7 @@ math::Vec3 amm_lp_base(Amm const& b, lep::LepAmmLX const& lep, had::HadLP const&
 struct Nrad {
 	Real coeff_born;
 	Real coeff_amm;
-	explicit Nrad(kin::Kinematics const& kin, Real k_0_bar);
+	Nrad(kin::Kinematics const& kin, ph::Phenom const& phenom, Real k_0_bar);
 };
 
 Real nrad_ir_uu_base(Nrad const& b, lep::LepNradUU const& lep, had::HadUU const& had);
@@ -285,7 +305,7 @@ math::Vec3 nrad_ir_lp_base(Nrad const& b, lep::LepNradLX const& lep, had::HadLP 
 struct Rad {
 	Real coeff;
 	Real R;
-	explicit Rad(kin::KinematicsRad const& kin);
+	Rad(kin::KinematicsRad const& kin, ph::Phenom const& phenom);
 };
 
 Real rad_uu_base(Rad const& b, lep::LepRadUU const& lep, had::HadRadUU const& had);

--- a/include/sidis/phenom.hpp
+++ b/include/sidis/phenom.hpp
@@ -1,0 +1,57 @@
+#ifndef SIDIS_PHENOM_HPP
+#define SIDIS_PHENOM_HPP
+
+#include "sidis/numeric.hpp"
+
+namespace sidis {
+
+namespace kin {
+	struct Kinematics;
+}
+
+namespace ph {
+
+/**
+ * \defgroup PhenomGroup Phenomenlogical inputs
+ * Types and functions used to calculate various phenomenological inputs needed
+ * for radiative corrections to the cross-section.
+ */
+/// \{
+
+/// QED coupling constant at electron mass.
+static Real const ALPHA_QED_0 = 1.L / 137.03599L;
+/// Calculates the QED coupling constant at a certain Q^2 value.
+Real alpha_qed(Real Q_sq=0.);
+/// Factor \f$\frac{\alpha}{\pi}\delta_{\text{vac}}^{\text{had}}\sigma_{B}\f$
+/// gives the vacuum polarization cross-section due to hadron loops.
+Real delta_vac_had(kin::Kinematics const& kin);
+
+/**
+ * Bundle of phenomenological inputs for the cross section, at a specific
+ * kinematics. This structure caches the phenomenological inputs so they can be
+ * re-used throughout various cross-section calculations. It also allows for
+ * custom phenomenological inputs to be provided, e.g., an improved hadron
+ * vacuum polarization calculation.
+ */
+struct Phenom {
+	/// Electromagnetic coupling constant, evolved to the scale of the process.
+	Real alpha_qed;
+	/// Contribution to vacuum polarization from hadrons.
+	Real delta_vac_had;
+
+	/// Computes the phenomenological inputs at the provided kinematics.
+	explicit Phenom(kin::Kinematics const& kin);
+	/// Choose the electromagnetic coupling constant, but compute the other
+	/// phenomenological inputs with the default method at the provided
+	/// kinematics.
+	Phenom(Real alpha_qed, kin::Kinematics const& kin);
+	/// Provide custom values for the phenomenological inputs.
+	Phenom(Real alpha_qed, Real delta_vac_had);
+};
+/// \}
+
+}
+}
+
+#endif
+

--- a/include/sidis/sidis.hpp
+++ b/include/sidis/sidis.hpp
@@ -13,6 +13,7 @@
 #include "sidis/leptonic_coeff.hpp"
 #include "sidis/numeric.hpp"
 #include "sidis/particle.hpp"
+#include "sidis/phenom.hpp"
 #include "sidis/structure_function.hpp"
 #include "sidis/tmd.hpp"
 #include "sidis/transform.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
 	"sidis/integ_params.hpp"
 	"sidis/kinematics.hpp"
 	"sidis/particle.hpp"
+	"sidis/phenom.hpp"
 	"sidis/tmd.hpp"
 	"sidis/transform.hpp"
 	"sidis/vector.hpp"
@@ -82,6 +83,7 @@ add_library(
 	leptonic_coeff.cpp
 	math.cpp
 	particle.cpp
+	phenom.cpp
 	structure_function.cpp
 	tmd.cpp
 	transform.cpp

--- a/src/asymmetry.cpp
+++ b/src/asymmetry.cpp
@@ -8,6 +8,7 @@
 #include "sidis/leptonic_coeff.hpp"
 #include "sidis/kinematics.hpp"
 #include "sidis/particle.hpp"
+#include "sidis/phenom.hpp"
 #include "sidis/structure_function.hpp"
 #include "sidis/vector.hpp"
 #include "sidis/extra/integrate.hpp"
@@ -17,6 +18,7 @@ using namespace sidis::asym;
 using namespace sidis::kin;
 using namespace sidis::math;
 using namespace sidis::part;
+using namespace sidis::ph;
 
 namespace {
 
@@ -36,7 +38,9 @@ EstErr ut_integ_h(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Born b(kin);
+				// TODO: Find a way to expose phenomenological inputs in the
+				// function interface.
+				xs::Born b(kin, Phenom(kin));
 				lep::LepBornUX lep(kin);
 				had::HadUP had(kin, sf);
 				Vec3 eta(
@@ -59,7 +63,7 @@ EstErr ut_integ_h(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Nrad b(kin, INF);
+				xs::Nrad b(kin, Phenom(kin), INF);
 				lep::LepNradUX lep(kin);
 				had::HadUP had(kin, sf);
 				Vec3 eta(
@@ -86,7 +90,7 @@ EstErr ut_integ_h(
 				}
 				jacobian *= phi_h_b.size();
 
-				xs::Rad b(kin_rad);
+				xs::Rad b(kin_rad, Phenom(kin));
 				sf::SfUP shift_sf = sf_set.sf_up(
 					ps.hadron,
 					kin_rad.shift_x, kin_rad.shift_z, kin_rad.shift_Q_sq, kin_rad.shift_ph_t_sq);
@@ -131,7 +135,7 @@ EstErr asym::uu_integ(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Born born(kin);
+				xs::Born born(kin, Phenom(kin));
 				lep::LepBornUU lep(kin);
 				had::HadUU had(kin, sf);
 				return xs::born_uu_base(born, lep, had);
@@ -149,7 +153,7 @@ EstErr asym::uu_integ(
 			[&](Real phi_h) {
 				PhaseSpace ph_space { x, y, z, ph_t_sq, phi_h, 0. };
 				Kinematics kin(ps, S, ph_space);
-				xs::Nrad b(kin, INF);
+				xs::Nrad b(kin, Phenom(kin), INF);
 				lep::LepNradUU lep(kin);
 				had::HadUU had(kin, sf);
 				return xs::nrad_ir_uu_base(b, lep, had);
@@ -171,7 +175,7 @@ EstErr asym::uu_integ(
 				}
 				jacobian *= phi_h_b.size();
 
-				xs::Rad b(kin_rad);
+				xs::Rad b(kin_rad, Phenom(kin));
 				sf::SfUU shift_sf = sf_set.sf_uu(
 					ps.hadron,
 					kin_rad.shift_x, kin_rad.shift_z, kin_rad.shift_Q_sq, kin_rad.shift_ph_t_sq);

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -11,6 +11,7 @@
 #include "sidis/hadronic_coeff.hpp"
 #include "sidis/kinematics.hpp"
 #include "sidis/leptonic_coeff.hpp"
+#include "sidis/phenom.hpp"
 #include "sidis/structure_function.hpp"
 #include "sidis/vector.hpp"
 #include "sidis/extra/integrate.hpp"
@@ -22,6 +23,7 @@ using namespace sidis::had;
 using namespace sidis::kin;
 using namespace sidis::lep;
 using namespace sidis::math;
+using namespace sidis::ph;
 using namespace sidis::sf;
 using namespace sidis::xs;
 
@@ -163,42 +165,42 @@ Real delta_vert_rad_0(Kinematics const& kin) {
 
 }
 
-Real xs::born(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
-	Born b(kin);
+Real xs::born(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	Born b(kin, phenom);
 	return SIDIS_MACRO_XS_FROM_BASE(born, LepBorn, Had, kin, sf, b, lambda_e, eta);
 }
 
-Real xs::amm(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
-	Amm b(kin);
+Real xs::amm(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	Amm b(kin, phenom);
 	return SIDIS_MACRO_XS_FROM_BASE(amm, LepAmm, Had, kin, sf, b, lambda_e, eta);
 }
 
-Real xs::nrad_ir(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar) {
-	Nrad b(kin, k_0_bar);
+Real xs::nrad_ir(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar) {
+	Nrad b(kin, phenom, k_0_bar);
 	return SIDIS_MACRO_XS_FROM_BASE(nrad_ir, LepNrad, Had, kin, sf, b, lambda_e, eta);
 }
 
-Real xs::rad(KinematicsRad const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
-	Rad b(kin);
+Real xs::rad(KinematicsRad const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	Rad b(kin, phenom);
 	return SIDIS_MACRO_XS_FROM_BASE_P(rad, LepRad, HadRad, kin, sf, b, lambda_e, eta);
 }
 
-Real xs::rad_f(KinematicsRad const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
-	Rad b(kin);
+Real xs::rad_f(KinematicsRad const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	Rad b(kin, phenom);
 	return SIDIS_MACRO_XS_FROM_BASE_P(rad_f, LepRad, HadRadF, kin, sf, b, lambda_e, eta);
 }
 
-EstErr xs::nrad_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
+EstErr xs::nrad_integ(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
 	// The soft part of the radiative cross-section (below `k_0_bar`) is bundled
 	// into the return value here.
-	Real xs_nrad_ir = nrad_ir(kin, sf, lambda_e, eta, k_0_bar);
+	Real xs_nrad_ir = nrad_ir(kin, phenom, sf, lambda_e, eta, k_0_bar);
 	// TODO: The integration parameters should be modified here to account for
 	// the `xs_nrad_ir` contribution.
-	EstErr xs_rad_f = rad_f_integ(kin, sf, lambda_e, eta, k_0_bar, params);
+	EstErr xs_rad_f = rad_f_integ(kin, phenom, sf, lambda_e, eta, k_0_bar, params);
 	return { xs_nrad_ir + xs_rad_f.val, xs_rad_f.err };
 }
 
-EstErr xs::rad_f_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
+EstErr xs::rad_f_integ(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
 	HadXX had_0(kin, sf);
 	CutRad cut;
 	cut.k_0_bar = Bound(0., k_0_bar);
@@ -210,7 +212,7 @@ EstErr xs::rad_f_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Ve
 				return 0.;
 			}
 
-			Rad b(kin_rad);
+			Rad b(kin_rad, phenom);
 			LepRadXX lep(kin_rad);
 			HadRadFXX had(kin_rad, sf, had_0);
 			Real uu = rad_f_uu_base(b, lep, had);
@@ -234,7 +236,7 @@ EstErr xs::rad_f_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Ve
 	return xs_integ;
 }
 
-EstErr xs::rad_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
+EstErr xs::rad_integ(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
 	CutRad cut;
 	cut.k_0_bar = Bound(k_0_bar, INF);
 	EstErr xs_integ = integrate<3>(
@@ -245,7 +247,7 @@ EstErr xs::rad_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3
 				return 0.;
 			}
 
-			Rad b(kin_rad);
+			Rad b(kin_rad, phenom);
 			LepRadXX lep(kin_rad);
 			HadRadXX had(kin_rad, sf);
 			Real uu = rad_uu_base(b, lep, had);
@@ -263,6 +265,31 @@ EstErr xs::rad_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3
 		std::array<Real, 3>{ 1., 1., 1. },
 		params);
 	return xs_integ;
+}
+
+Real xs::born(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	return born(kin, Phenom(kin), sf, lambda_e, eta);
+}
+Real xs::amm(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	return amm(kin, Phenom(kin), sf, lambda_e, eta);
+}
+Real xs::nrad_ir(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar) {
+	return nrad_ir(kin, Phenom(kin), sf, lambda_e, eta, k_0_bar);
+}
+Real xs::rad(KinematicsRad const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	return rad(kin, Phenom(kin.project()), sf, lambda_e, eta);
+}
+Real xs::rad_f(KinematicsRad const& kin, SfSet const& sf, Real lambda_e, Vec3 eta) {
+	return rad_f(kin, Phenom(kin.project()), sf, lambda_e, eta);
+}
+EstErr xs::nrad_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
+	return nrad_integ(kin, Phenom(kin), sf, lambda_e, eta, k_0_bar, params);
+}
+EstErr xs::rad_f_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
+	return rad_f_integ(kin, Phenom(kin), sf, lambda_e, eta, k_0_bar, params);
+}
+EstErr xs::rad_integ(Kinematics const& kin, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
+	return rad_integ(kin, Phenom(kin), sf, lambda_e, eta, k_0_bar, params);
 }
 
 // Radiative corrections to Born cross-section.
@@ -324,20 +351,10 @@ Real xs::delta_vac_lep(Kinematics const& kin) {
 	return delta;
 }
 
-Real xs::delta_vac_had(Kinematics const& kin) {
-	if (kin.Q_sq < 1.) {
-		return -(2.*PI)/ALPHA*(-1.345e-9L - 2.302e-3L*std::log(1. + 4.091L*kin.Q_sq));
-	} else if (kin.Q_sq < 64.) {
-		return -(2.*PI)/ALPHA*(-1.512e-3L - 2.822e-3L*std::log(1. + 1.218L*kin.Q_sq));
-	} else {
-		return -(2.*PI)/ALPHA*(-1.1344e-3L - 3.0680e-3L*std::log(1. + 0.99992L*kin.Q_sq));
-	}
-}
-
 // Born base functions.
-Born::Born(Kinematics const& kin) :
+Born::Born(Kinematics const& kin, Phenom const& phenom) :
 	// Equation [1.15]. The `Q^4` factor has been absorbed into `C_1`.
-	coeff((sq(ALPHA)*kin.S*sq(kin.S_x))/(8.*kin.M*kin.ph_l*kin.lambda_S)) { }
+	coeff((sq(phenom.alpha_qed)*kin.S*sq(kin.S_x))/(8.*kin.M*kin.ph_l*kin.lambda_S)) { }
 
 Real xs::born_uu_base(Born const& b, LepBornUU const& lep, HadUU const& had) {
 	return b.coeff*(
@@ -385,14 +402,14 @@ Vec3 xs::born_lp_base(Born const& b, LepBornLX const& lep, HadLP const& had) {
 }
 
 // AMM base functions.
-Amm::Amm(Kinematics const& kin) {
+Amm::Amm(Kinematics const& kin, Phenom const& phenom) {
 	// Equation [1.53]. The `Q^4` factor has been absorbed into `C_1`.
 	Real lambda_m = kin.Q_sq*(kin.Q_sq + 4.*sq(kin.m));
 	Real lambda_m_sqrt = std::sqrt(lambda_m);
 	Real diff_m = sqrt1p_1m((4.*sq(kin.m))/kin.Q_sq);
 	Real sum_m = 2. + diff_m;
 	Real L_m = 1./lambda_m_sqrt*std::log(sum_m/diff_m);
-	coeff = L_m*kin.Q_sq*(std::pow(ALPHA, 3)*sq(kin.m)*kin.S*sq(kin.S_x))
+	coeff = L_m*kin.Q_sq*(std::pow(phenom.alpha_qed, 3)*sq(kin.m)*kin.S*sq(kin.S_x))
 		/(16.*PI*kin.M*kin.ph_l*kin.lambda_S);
 }
 
@@ -442,13 +459,13 @@ Vec3 xs::amm_lp_base(Amm const& b, LepAmmLX const& lep, HadLP const& had) {
 }
 
 // Non-radiative infrared-divergence-free base functions.
-Nrad::Nrad(Kinematics const& kin, Real k_0_bar) {
-	Born born(kin);
-	Amm amm(kin);
-	Real born_factor = 1. + ALPHA/PI*(
+Nrad::Nrad(Kinematics const& kin, Phenom const& phenom, Real k_0_bar) {
+	Born born(kin, phenom);
+	Amm amm(kin, phenom);
+	Real born_factor = 1. + phenom.alpha_qed/PI*(
 		delta_vert_rad_ir(kin, k_0_bar)
 		+ delta_vac_lep(kin)
-		+ delta_vac_had(kin));
+		+ phenom.delta_vac_had);
 	coeff_born = born_factor*born.coeff;
 	coeff_amm = amm.coeff;
 }
@@ -507,9 +524,9 @@ Vec3 xs::nrad_ir_lp_base(Nrad const& b, LepNradLX const& lep, HadLP const& had) 
 }
 
 // Radiative base functions.
-Rad::Rad(KinematicsRad const& kin) {
+Rad::Rad(KinematicsRad const& kin, Phenom const& phenom) {
 	// Equation [1.43].
-	coeff = -(std::pow(ALPHA, 3)*kin.S*sq(kin.S_x))
+	coeff = -(std::pow(phenom.alpha_qed, 3)*kin.S*sq(kin.S_x))
 		/(64.*sq(PI)*kin.M*kin.ph_l*kin.lambda_S*kin.lambda_Y_sqrt);
 	R = kin.R;
 }

--- a/src/phenom.cpp
+++ b/src/phenom.cpp
@@ -1,0 +1,92 @@
+#include "sidis/phenom.hpp"
+
+#include <cmath>
+
+#include "sidis/constant.hpp"
+#include "sidis/kinematics.hpp"
+#include "sidis/extra/interpolate.hpp"
+
+using namespace sidis;
+using namespace sidis::kin;
+using namespace sidis::ph;
+
+namespace {
+
+Real const Q_SQ_MAX = 100.;
+Real const NF = 1.;
+Real const BETA_0 = 4. / 3. * NF;
+
+Real beta_qed(Real alpha) {
+	Real alpha_r = alpha / (4. * PI);
+	return 4. * PI * BETA_0 * (1. + 3. * alpha_r) * alpha_r * alpha_r;
+}
+
+interp::Grid<Real, 1> create_alpha_qed_grid(Real Q_sq_max) {
+	std::vector<Real> ln_Q_sq_vals { 2. * std::log(MASS_E) };
+	std::vector<Real> alpha_vals { ALPHA_QED_0 };
+	// Generate points until a couple of points after max Q^2 is reached, to
+	// ensure that cubic interpolation will work well until the end.
+	std::size_t extra = 8;
+	while (ln_Q_sq_vals.size() < extra
+			|| ln_Q_sq_vals[ln_Q_sq_vals.size() - extra] <= std::log(Q_sq_max)) {
+		// RK4 evolution.
+		Real step = 0.01;
+		Real ln_Q_sq_0 = ln_Q_sq_vals.back();
+		Real ln_Q_sq_1 = ln_Q_sq_0 + step;
+		Real alpha_0 = alpha_vals.back();
+		Real alpha_p1 = beta_qed(alpha_0);
+		Real alpha_p2 = beta_qed(alpha_0 + 0.5 * step * alpha_p1);
+		Real alpha_p3 = beta_qed(alpha_0 + 0.5 * step * alpha_p2);
+		Real alpha_p4 = beta_qed(alpha_0 + step * alpha_p3);
+		Real alpha_1 = alpha_0
+			+ step * (alpha_p1 + 2. * alpha_p2 + 2. * alpha_p3 + alpha_p4) / 6.;
+		alpha_vals.push_back(alpha_1);
+		ln_Q_sq_vals.push_back(ln_Q_sq_1);
+	}
+	return interp::Grid<Real, 1>(
+		alpha_vals.data(),
+		{ ln_Q_sq_vals.size() }, { ln_Q_sq_vals.front() }, { ln_Q_sq_vals.back() });
+}
+
+interp::Grid<Real, 1> const alpha_qed_grid = create_alpha_qed_grid(Q_SQ_MAX);
+
+}
+
+Real ph::alpha_qed(Real Q_sq) {
+	auto cubic_view = interp::CubicView<Real, 1>(alpha_qed_grid);
+	if (Q_sq < Q_SQ_MAX) {
+		// Note that if Q^2 is smaller than the electron mass, this will NaN.
+		// Since this is well out of the DIS regime, this isn't a problem.
+		return cubic_view({ std::log(Q_sq) });
+	} else {
+		// Use analytic expression to continue past the end of the grid. This is
+		// the one-loop result.
+		Real alpha_r_max = cubic_view({ std::log(Q_SQ_MAX) }) / (4. * PI);
+		return 4. * PI * alpha_r_max
+			/ (1. - alpha_r_max * BETA_0 * std::log(Q_sq / Q_SQ_MAX));
+	}
+}
+
+Real ph::delta_vac_had(Kinematics const& kin) {
+	// TODO: This vacuum hadron polarization calculation needs to be replaced
+	// with a better one.
+	Real alpha = 7.2973525664e-3L;
+	if (kin.Q_sq < 1.) {
+		return -(2.*PI)/alpha*(-1.345e-9L - 2.302e-3L*std::log(1. + 4.091L*kin.Q_sq));
+	} else if (kin.Q_sq < 64.) {
+		return -(2.*PI)/alpha*(-1.512e-3L - 2.822e-3L*std::log(1. + 1.218L*kin.Q_sq));
+	} else {
+		return -(2.*PI)/alpha*(-1.1344e-3L - 3.0680e-3L*std::log(1. + 0.99992L*kin.Q_sq));
+	}
+}
+
+Phenom::Phenom(Kinematics const& kin) :
+	alpha_qed(ph::alpha_qed(kin.Q_sq)),
+	delta_vac_had(ph::delta_vac_had(kin)) { }
+Phenom::Phenom(Real alpha_qed, Kinematics const& kin) :
+	alpha_qed(alpha_qed),
+	delta_vac_had(ph::delta_vac_had(kin)) { }
+Phenom::Phenom(Real alpha_qed, Real delta_vac_had) :
+	alpha_qed(alpha_qed),
+	delta_vac_had(delta_vac_had) { }
+

--- a/test/test_cross_section.cpp
+++ b/test/test_cross_section.cpp
@@ -19,6 +19,9 @@ using namespace sidis;
 
 namespace {
 
+// We use a fixed value of alpha for the comparisons.
+Real const ALPHA = 7.2973525664e-3L;
+
 struct Input {
 	int sf_set_idx;
 	Real k0_cut;
@@ -210,9 +213,10 @@ TEST_CASE(
 	Real beam_pol = input.beam_pol;
 	math::Vec3 eta = frame::hadron_from_target(kin) * input.target_pol;
 	// Compute the cross-sections.
-	Real born = xs::born(kin, *sf, beam_pol, eta);
-	Real amm = xs::amm(kin, *sf, beam_pol, eta);
-	Real nrad = xs::nrad_ir(kin, *sf, beam_pol, eta, input.k0_cut);
+	ph::Phenom phenom(ALPHA, kin);
+	Real born = xs::born(kin, phenom, *sf, beam_pol, eta);
+	Real amm = xs::amm(kin, phenom, *sf, beam_pol, eta);
+	Real nrad = xs::nrad_ir(kin, phenom, *sf, beam_pol, eta, input.k0_cut);
 
 	// Print state information.
 	std::stringstream ss;
@@ -282,8 +286,9 @@ TEST_CASE(
 	Real beam_pol = input.beam_pol;
 	math::Vec3 eta = frame::hadron_from_target(kin.project()) * input.target_pol;
 	// Compute the cross-sections.
-	Real rad_f = xs::rad_f(kin, *sf, beam_pol, eta);
-	Real rad = xs::rad(kin, *sf, beam_pol, eta);
+	ph::Phenom phenom(ALPHA, kin.project());
+	Real rad_f = xs::rad_f(kin, phenom, *sf, beam_pol, eta);
+	Real rad = xs::rad(kin, phenom, *sf, beam_pol, eta);
 
 	// Print state information.
 	std::stringstream ss;


### PR DESCRIPTION
We want the user to be able to override the built-in values for alpha QED and the hadronic vacuum polarizations, as well as possibly other phenomenological inputs to the cross section. This PR exposes those inputs in the API so that they can be overridden.

In addition, Q^2 evolution of alpha QED is added.