### PR TITLE
Refactor TMD interfaces

### DIFF
--- a/app/sidisgen/generator.cpp
+++ b/app/sidisgen/generator.cpp
@@ -97,16 +97,16 @@ NradDensity::NradDensity(Params& params, sf::SfSet const& sf) :
 Double NradDensity::transform(
 		Point<6> const& unit_vec,
 		kin::Kinematics* kin) const noexcept {
-	Double jacobian;
-	if (!cut::take(_cut, _ps, _S, unit_vec.data(), kin, &jacobian)) {
-		jacobian = 0.;
+	Double jac;
+	if (!cut::take(_cut, _ps, _S, unit_vec.data(), kin, &jac)) {
+		jac = 0.;
 	}
-	return jacobian;
+	return jac;
 }
 
 Double NradDensity::eval(Point<6> const& unit_vec, kin::Kinematics* kin) const noexcept {
-	Double jacobian;
-	if (!cut::take(_cut, _ps, _S, unit_vec.data(), kin, &jacobian)) {
+	Double jac;
+	if (!cut::take(_cut, _ps, _S, unit_vec.data(), kin, &jac)) {
 		return 0.;
 	}
 	math::Vec3 eta = frame::hadron_from_target(*kin) * _target_pol;
@@ -136,7 +136,7 @@ Double NradDensity::eval(Point<6> const& unit_vec, kin::Kinematics* kin) const n
 	if (!std::isfinite(xs) || !(xs >= 0.)) {
 		return 0.;
 	} else {
-		return jacobian * xs;
+		return jac * xs;
 	}
 }
 
@@ -176,16 +176,16 @@ RadDensity::RadDensity(Params& params, sf::SfSet const& sf) :
 Double RadDensity::transform(
 		Point<9> const& unit_vec,
 		kin::KinematicsRad* kin) const noexcept {
-	Double jacobian;
-	if (!cut::take(_cut, _cut_rad, _ps, _S, unit_vec.data(), kin, &jacobian)) {
-		jacobian = 0.;
+	Double jac;
+	if (!cut::take(_cut, _cut_rad, _ps, _S, unit_vec.data(), kin, &jac)) {
+		jac = 0.;
 	}
-	return jacobian;
+	return jac;
 }
 
 Double RadDensity::eval(Point<9> const& unit_vec, kin::KinematicsRad* kin_rad) const noexcept {
-	Double jacobian;
-	if (!cut::take(_cut, _cut_rad, _ps, _S, unit_vec.data(), kin_rad, &jacobian)) {
+	Double jac;
+	if (!cut::take(_cut, _cut_rad, _ps, _S, unit_vec.data(), kin_rad, &jac)) {
 		return 0.;
 	}
 	kin::Kinematics kin = kin_rad->project();
@@ -194,7 +194,7 @@ Double RadDensity::eval(Point<9> const& unit_vec, kin::KinematicsRad* kin_rad) c
 	if (!std::isfinite(xs) || !(xs >= 0.)) {
 		return 0.;
 	} else {
-		return jacobian * xs;
+		return jac * xs;
 	}
 }
 

--- a/include/sidis/extra/exception.hpp
+++ b/include/sidis/extra/exception.hpp
@@ -83,6 +83,22 @@ public:
 };
 
 /**
+ * A FlavorVec was a different size than expected.
+ */
+class FlavorVecUnexpectedSize final : public std::exception {
+	std::string _what;
+
+public:
+	unsigned size;
+	unsigned expected_size;
+
+	FlavorVecUnexpectedSize(unsigned size, unsigned expected_size);
+	char const* what() const noexcept override {
+		return _what.c_str();
+	}
+};
+
+/**
  * Disallowed hadron in a FF.
  *
  * This exception is intended for use in user-defined FFs to indicate an

--- a/include/sidis/flavor_vec.hpp
+++ b/include/sidis/flavor_vec.hpp
@@ -62,7 +62,7 @@ public:
 		}
 	}
 	/// Initialize a FlavorVec from a single number.
-	FlavorVec(Real val) : _arr{val}, _size(1) { }
+	explicit FlavorVec(Real val) : _arr{val}, _size(1) { }
 	/// Initialize a FlavorVec from an initializer list.
 	FlavorVec(std::initializer_list<Real> list);
 
@@ -79,6 +79,18 @@ public:
 	FlavorVec& operator/=(Real scale) {
 		for (unsigned fl = 0; fl < _size; ++fl) {
 			_arr[fl] /= scale;
+		}
+		return *this;
+	}
+	FlavorVec& operator+=(Real offset) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] += offset;
+		}
+		return *this;
+	}
+	FlavorVec& operator-=(Real offset) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] -= offset;
 		}
 		return *this;
 	}
@@ -137,8 +149,15 @@ public:
 	/// \}
 
 	friend FlavorVec tmd_gaussian_factor(FlavorVec var, Real k_perp_sq);
+	friend inline FlavorVec operator-(FlavorVec vec) {
+		for (unsigned fl = 0; fl < vec._size; ++fl) {
+			vec._arr[fl] = -vec._arr[fl];
+		}
+		return vec;
+	}
 };
 
+// Arithmetic with real numbers.
 inline FlavorVec operator*(FlavorVec lhs, Real rhs) {
 	lhs *= rhs;
 	return lhs;
@@ -147,6 +166,7 @@ inline FlavorVec operator*(Real lhs, FlavorVec rhs) {
 	rhs *= lhs;
 	return rhs;
 }
+
 inline FlavorVec operator/(FlavorVec lhs, Real rhs) {
 	lhs /= rhs;
 	return lhs;
@@ -155,6 +175,26 @@ inline FlavorVec operator/(Real lhs, FlavorVec rhs) {
 	rhs.inv(lhs);
 	return rhs;
 }
+
+inline FlavorVec operator+(FlavorVec lhs, Real rhs) {
+	lhs += rhs;
+	return lhs;
+}
+inline FlavorVec operator+(Real lhs, FlavorVec rhs) {
+	rhs += lhs;
+	return rhs;
+}
+
+inline FlavorVec operator-(FlavorVec lhs, Real rhs) {
+	lhs -= rhs;
+	return lhs;
+}
+inline FlavorVec operator-(Real lhs, FlavorVec rhs) {
+	rhs -= lhs;
+	return -rhs;
+}
+
+// Arithemetic with two FlavorVec%s.
 inline FlavorVec operator+(FlavorVec lhs, FlavorVec const& rhs) {
 	lhs += rhs;
 	return lhs;
@@ -170,12 +210,6 @@ inline FlavorVec operator*(FlavorVec lhs, FlavorVec const& rhs) {
 inline FlavorVec operator/(FlavorVec lhs, FlavorVec const& rhs) {
 	lhs /= rhs;
 	return lhs;
-}
-inline FlavorVec operator-(FlavorVec vec) {
-	for (unsigned fl = 0; fl < vec.size(); ++fl) {
-		vec[fl] = -vec[fl];
-	}
-	return vec;
 }
 
 FlavorVec sqrt_vec(FlavorVec vec);

--- a/include/sidis/flavor_vec.hpp
+++ b/include/sidis/flavor_vec.hpp
@@ -1,0 +1,197 @@
+#ifndef SIDIS_FLAVOR_VEC_HPP
+#define SIDIS_FLAVOR_VEC_HPP
+
+#include <initializer_list>
+
+#include "sidis/numeric.hpp"
+
+namespace sidis {
+namespace sf {
+
+/// Maximum number of TMD flavors supported in user-defined TMDs.
+unsigned const MAX_FLAVOR_VEC_SIZE = 8;
+
+/**
+ * An aggregate of results from a TMD or FF calculation (from TmdSet), one entry
+ * for each parton flavor. The contributions from each flavor are eventually
+ * summed together to make a complete structure function by SfSet.
+ *
+ * Internally, a FlavorVec is a stack-allocated array. Its size cannot be larger
+ * than the constant MAX_FLAVOR_ARRAY_SIZE.
+ *
+ * For convenience, FlavorVec%s can be added, subtracted, and multiplied
+ * together.
+ *
+ * \sa TmdSet
+ */
+class FlavorVec final {
+	// Implemented basically as a smallvec.
+	Real _arr[MAX_FLAVOR_VEC_SIZE];
+	unsigned _size;
+	// Raises an error when a FlavorVec is constructed with a size greater than
+	// MAX_FLAVOR_ARRAY_SIZE.
+	void raise_out_of_range(unsigned size) const;
+
+public:
+	/// Construct a zero-valued FlavorVec of length \p count, which must be less
+	/// than MAX_FLAVOR_ARRAY_SIZE.
+	explicit FlavorVec(unsigned count) : _arr{}, _size(count) {
+		if (_size > MAX_FLAVOR_VEC_SIZE) {
+			raise_out_of_range(_size);
+		}
+	}
+	/// Construct a constant-valued FlavorVec of \p count entries of \p value.
+	/// \p count must be less than MAX_FLAVOR_ARRAY_SIZE.
+	FlavorVec(unsigned count, Real value) : _arr{}, _size(count) {
+		if (_size > MAX_FLAVOR_VEC_SIZE) {
+			raise_out_of_range(_size);
+		}
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] = value;
+		}
+	}
+	/// Initialize a FlavorVec from a range.
+	template<typename It>
+	FlavorVec(It begin, It end) {
+		for (It it = begin; it != end; ++it) {
+			if (_size >= MAX_FLAVOR_VEC_SIZE) {
+				raise_out_of_range(_size + 1);
+			}
+			_arr[_size] = *it;
+			++_size;
+		}
+	}
+	/// Initialize a FlavorVec from a single number.
+	FlavorVec(Real val) : _arr{val}, _size(1) { }
+	/// Initialize a FlavorVec from an initializer list.
+	FlavorVec(std::initializer_list<Real> list);
+
+	/// \name Arithmetic operations
+	/// Note that these operations are undefined if the operands have different
+	/// sizes (i.e. adding together a length 3 and 4 FlavorVec).
+	/// \{
+	FlavorVec& operator*=(Real scale) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] *= scale;
+		}
+		return *this;
+	}
+	FlavorVec& operator/=(Real scale) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] /= scale;
+		}
+		return *this;
+	}
+	FlavorVec& operator+=(FlavorVec const& rhs) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] += rhs._arr[fl];
+		}
+		return *this;
+	}
+	FlavorVec& operator-=(FlavorVec const& rhs) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] -= rhs._arr[fl];
+		}
+		return *this;
+	}
+	FlavorVec& operator*=(FlavorVec const& rhs) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] *= rhs._arr[fl];
+		}
+		return *this;
+	}
+	FlavorVec& operator/=(FlavorVec const& rhs) {
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			_arr[fl] /= rhs._arr[fl];
+		}
+		return *this;
+	}
+	FlavorVec& inv(Real scale=1.) {
+		for (unsigned fl = 0.; fl < _size; ++fl) {
+			_arr[fl] = scale / _arr[fl];
+		}
+		return *this;
+	}
+	/// \}
+
+	/// Totals together all of the entries.
+	Real sum() const {
+		Real result = 0.;
+		for (unsigned fl = 0; fl < _size; ++fl) {
+			result += _arr[fl];
+		}
+		return result;
+	}
+
+	/// \name Array access
+	/// \{
+	unsigned size() const {
+		return _size;
+	}
+	Real const& operator[](unsigned fl) const {
+		return _arr[fl];
+	}
+	Real& operator[](unsigned fl) {
+		return _arr[fl];
+	}
+	/// \}
+
+	friend FlavorVec tmd_gaussian_factor(FlavorVec var, Real k_perp_sq);
+};
+
+inline FlavorVec operator*(FlavorVec lhs, Real rhs) {
+	lhs *= rhs;
+	return lhs;
+}
+inline FlavorVec operator*(Real lhs, FlavorVec rhs) {
+	rhs *= lhs;
+	return rhs;
+}
+inline FlavorVec operator/(FlavorVec lhs, Real rhs) {
+	lhs /= rhs;
+	return lhs;
+}
+inline FlavorVec operator/(Real lhs, FlavorVec rhs) {
+	rhs.inv(lhs);
+	return rhs;
+}
+inline FlavorVec operator+(FlavorVec lhs, FlavorVec const& rhs) {
+	lhs += rhs;
+	return lhs;
+}
+inline FlavorVec operator-(FlavorVec lhs, FlavorVec const& rhs) {
+	lhs -= rhs;
+	return lhs;
+}
+inline FlavorVec operator*(FlavorVec lhs, FlavorVec const& rhs) {
+	lhs *= rhs;
+	return lhs;
+}
+inline FlavorVec operator/(FlavorVec lhs, FlavorVec const& rhs) {
+	lhs /= rhs;
+	return lhs;
+}
+inline FlavorVec operator-(FlavorVec vec) {
+	for (unsigned fl = 0; fl < vec.size(); ++fl) {
+		vec[fl] = -vec[fl];
+	}
+	return vec;
+}
+
+FlavorVec sqrt_vec(FlavorVec vec);
+FlavorVec sq_vec(FlavorVec vec);
+FlavorVec exp_vec(FlavorVec vec);
+FlavorVec pow_vec(Real lhs, FlavorVec rhs);
+FlavorVec pow_vec(FlavorVec lhs, Real rhs);
+FlavorVec pow_vec(FlavorVec lhs, FlavorVec const& rhs);
+
+/// Convenience function for computing the factor that shows up in many
+/// Gaussian TMDs. The flavor-dependent variance of the Gaussian is given by
+/// \p var, and the momentum at which to evaluate the Gaussian is \p k_perp_sq.
+FlavorVec tmd_gaussian_factor(FlavorVec var, Real k_perp_sq);
+
+}
+}
+
+#endif
+

--- a/include/sidis/sf_set/prokudin.hpp
+++ b/include/sidis/sf_set/prokudin.hpp
@@ -29,19 +29,17 @@ public:
 	ProkudinTmdSet& operator=(ProkudinTmdSet&& other) noexcept;
 	virtual ~ProkudinTmdSet();
 
-	Real charge(unsigned fl) const override;
+	FlavorVec xf1(Real x, Real Q_sq) const override;
+	FlavorVec xf1Tperp(Real x, Real Q_sq) const override;
+	FlavorVec xg1(Real x, Real Q_sq) const override;
+	FlavorVec xg1Tperp(Real x, Real Q_sq) const override;
+	FlavorVec xh1(Real x, Real Q_sq) const override;
+	FlavorVec xh1perp(Real x, Real Q_sq) const override;
+	FlavorVec xh1Lperp(Real x, Real Q_sq) const override;
+	FlavorVec xh1Tperp(Real x, Real Q_sq) const override;
 
-	Real xf1(unsigned fl, Real x, Real Q_sq) const override;
-	Real xf1Tperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xg1(unsigned fl, Real x, Real Q_sq) const override;
-	Real xg1Tperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xh1(unsigned fl, Real x, Real Q_sq) const override;
-	Real xh1perp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xh1Lperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xh1Tperp(unsigned fl, Real x, Real Q_sq) const override;
-
-	Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
-	Real H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
+	FlavorVec D1(part::Hadron h, Real z, Real Q_sq) const override;
+	FlavorVec H1perp(part::Hadron h, Real z, Real Q_sq) const override;
 };
 
 /**
@@ -52,19 +50,19 @@ class ProkudinSfSet final : public SfSet {
 	Impl* _impl;
 
 	// Fragmentation functions.
-	Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
-	Real H1perpM1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
+	FlavorVec D1(part::Hadron h, Real z, Real Q_sq) const;
+	FlavorVec H1perpM1(part::Hadron h, Real z, Real Q_sq) const;
 
 	// Transverse momentum distributions.
-	Real xf1(unsigned fl, Real x, Real Q_sq) const;
-	Real xf1TperpM1(unsigned fl, Real x, Real Q_sq) const;
-	Real xg1(unsigned fl, Real x, Real Q_sq) const;
-	Real xgT(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1M1(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1LperpM1(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1TperpM2(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1perpM1(unsigned fl, Real x, Real Q_sq) const;
+	FlavorVec xf1(Real x, Real Q_sq) const;
+	FlavorVec xf1TperpM1(Real x, Real Q_sq) const;
+	FlavorVec xg1(Real x, Real Q_sq) const;
+	FlavorVec xgT(Real x, Real Q_sq) const;
+	FlavorVec xh1(Real x, Real Q_sq) const;
+	FlavorVec xh1M1(Real x, Real Q_sq) const;
+	FlavorVec xh1LperpM1(Real x, Real Q_sq) const;
+	FlavorVec xh1TperpM2(Real x, Real Q_sq) const;
+	FlavorVec xh1perpM1(Real x, Real Q_sq) const;
 
 public:
 	ProkudinSfSet();

--- a/include/sidis/sidis.hpp
+++ b/include/sidis/sidis.hpp
@@ -6,6 +6,7 @@
 #include "sidis/constant.hpp"
 #include "sidis/cross_section.hpp"
 #include "sidis/cut.hpp"
+#include "sidis/flavor_vec.hpp"
 #include "sidis/frame.hpp"
 #include "sidis/hadronic_coeff.hpp"
 #include "sidis/integ_params.hpp"

--- a/include/sidis/structure_function.hpp
+++ b/include/sidis/structure_function.hpp
@@ -217,6 +217,24 @@ public:
 	Real F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
 	Real F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
 	Real F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+
+	SfBaseUU sf_base_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseUL sf_base_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseUT sf_base_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseUP sf_base_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLU sf_base_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLL sf_base_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLT sf_base_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLP sf_base_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+
+	SfUU sf_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfUL sf_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfUT sf_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfUP sf_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLU sf_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLL sf_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLT sf_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLP sf_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
 };
 
 /**
@@ -302,6 +320,24 @@ public:
 	Real F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
 	Real F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
 	Real F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+
+	SfBaseUU sf_base_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseUL sf_base_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseUT sf_base_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseUP sf_base_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLU sf_base_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLL sf_base_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLT sf_base_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfBaseLP sf_base_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+
+	SfUU sf_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfUL sf_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfUT sf_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfUP sf_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLU sf_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLL sf_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLT sf_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
+	SfLP sf_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const override;
 };
 
 /**

--- a/include/sidis/structure_function.hpp
+++ b/include/sidis/structure_function.hpp
@@ -305,14 +305,13 @@ public:
 };
 
 /**
- * \defgroup SfCombsBaseGroup Base structure function combinations
+ * \defgroup SfCombsGroup Base structure function combinations
  * These types cache the results of structure function calculations from SfSet.
  * They are grouped by beam and target polarization. For instance, for
  * calculating the LT part of the cross-section through xs::born_base_lt(), you
- * would fill in the SfBaseLT type.
- *
- * To compute the full LT cross-section (including unpolarized contributions),
- * you would instead fill in the SfLT type.
+ * would fill in the SfBaseLT type. Or, to compute the full LT cross-section
+ * (including unpolarized contributions), you would instead fill in the SfLT
+ * type.
  *
  * \sa SfSet
  */
@@ -355,18 +354,7 @@ struct SfBaseLP {
 	SfBaseLL ll;
 	SfBaseLT lt;
 };
-/// \}
 
-/**
- * \defgroup SfCombsGroup Structure function combinations
- * These types combine the base structure function combinations together so that
- * a complete polarized cross-section can be calculated. For instance, if you
- * want to calculate an LT cross-section, you need to combine the UU, UT, LU,
- * and LT parts of the cross-section.
- *
- * \sa SfSet
- */
-/// \{
 struct SfUU {
 	SfBaseUU uu;
 };

--- a/include/sidis/tmd.hpp
+++ b/include/sidis/tmd.hpp
@@ -1,6 +1,7 @@
 #ifndef SIDIS_TMD_HPP
 #define SIDIS_TMD_HPP
 
+#include "sidis/constant.hpp"
 #include "sidis/flavor_vec.hpp"
 #include "sidis/particle.hpp"
 
@@ -94,45 +95,45 @@ struct GaussianWwTmdVars;
 struct GaussianTmdVars {
 	/// \name Variances of TMDs
 	/// \{
-	FlavorVec f1;
-	FlavorVec f1Tperp;
-	FlavorVec fT;
-	FlavorVec fperp;
-	FlavorVec fLperp;
-	FlavorVec fTperp;
-	FlavorVec g1;
-	FlavorVec g1Tperp;
-	FlavorVec gT;
-	FlavorVec gperp;
-	FlavorVec gLperp;
-	FlavorVec gTperp;
-	FlavorVec h1;
-	FlavorVec h1perp;
-	FlavorVec h1Lperp;
-	FlavorVec h1Tperp;
-	FlavorVec h;
-	FlavorVec hL;
-	FlavorVec hT;
-	FlavorVec hTperp;
-	FlavorVec e;
-	FlavorVec eL;
-	FlavorVec eT;
-	FlavorVec eTperp;
+	FlavorVec f1          = FlavorVec(1, INF);
+	FlavorVec f1Tperp     = FlavorVec(1, INF);
+	FlavorVec fT          = FlavorVec(1, INF);
+	FlavorVec fperp       = FlavorVec(1, INF);
+	FlavorVec fLperp      = FlavorVec(1, INF);
+	FlavorVec fTperp      = FlavorVec(1, INF);
+	FlavorVec g1          = FlavorVec(1, INF);
+	FlavorVec g1Tperp     = FlavorVec(1, INF);
+	FlavorVec gT          = FlavorVec(1, INF);
+	FlavorVec gperp       = FlavorVec(1, INF);
+	FlavorVec gLperp      = FlavorVec(1, INF);
+	FlavorVec gTperp      = FlavorVec(1, INF);
+	FlavorVec h1          = FlavorVec(1, INF);
+	FlavorVec h1perp      = FlavorVec(1, INF);
+	FlavorVec h1Lperp     = FlavorVec(1, INF);
+	FlavorVec h1Tperp     = FlavorVec(1, INF);
+	FlavorVec h           = FlavorVec(1, INF);
+	FlavorVec hL          = FlavorVec(1, INF);
+	FlavorVec hT          = FlavorVec(1, INF);
+	FlavorVec hTperp      = FlavorVec(1, INF);
+	FlavorVec e           = FlavorVec(1, INF);
+	FlavorVec eL          = FlavorVec(1, INF);
+	FlavorVec eT          = FlavorVec(1, INF);
+	FlavorVec eTperp      = FlavorVec(1, INF);
 	/// \}
 
 	/// \name Variances of FFs
 	/// \{
-	FlavorVec D1;
-	FlavorVec H1perp;
-	FlavorVec Dperp_tilde;
-	FlavorVec H_tilde;
-	FlavorVec Gperp_tilde;
-	FlavorVec E_tilde;
+	FlavorVec D1          = FlavorVec(1, INF);
+	FlavorVec H1perp      = FlavorVec(1, INF);
+	FlavorVec Dperp_tilde = FlavorVec(1, INF);
+	FlavorVec H_tilde     = FlavorVec(1, INF);
+	FlavorVec Gperp_tilde = FlavorVec(1, INF);
+	FlavorVec E_tilde     = FlavorVec(1, INF);
 	/// \}
 
 	/// Initializes the variances. Each variance is set to be infinity by
 	/// default, which means the corresponding TMD will be completely neglected.
-	explicit GaussianTmdVars();
+	GaussianTmdVars() { }
 	/// Initializes the variances using the variances for the Wandzura-Wilczek
 	/// base set of TMDs and FFs.
 	explicit GaussianTmdVars(GaussianWwTmdVars const& ww_vars);
@@ -324,31 +325,31 @@ public:
 struct GaussianWwTmdVars {
 	/// \name Variances of TMDs
 	/// \{
-	FlavorVec f1;
-	FlavorVec f1Tperp;
-	FlavorVec fT;
-	FlavorVec g1;
-	FlavorVec g1Tperp;
-	FlavorVec gT;
-	FlavorVec h1;
-	FlavorVec h1perp;
-	FlavorVec h1Lperp;
-	FlavorVec h1Tperp;
-	FlavorVec h;
-	FlavorVec hL;
-	FlavorVec hT;
-	FlavorVec hTperp;
+	FlavorVec f1      = FlavorVec(1, INF);
+	FlavorVec f1Tperp = FlavorVec(1, INF);
+	FlavorVec fT      = FlavorVec(1, INF);
+	FlavorVec g1      = FlavorVec(1, INF);
+	FlavorVec g1Tperp = FlavorVec(1, INF);
+	FlavorVec gT      = FlavorVec(1, INF);
+	FlavorVec h1      = FlavorVec(1, INF);
+	FlavorVec h1perp  = FlavorVec(1, INF);
+	FlavorVec h1Lperp = FlavorVec(1, INF);
+	FlavorVec h1Tperp = FlavorVec(1, INF);
+	FlavorVec h       = FlavorVec(1, INF);
+	FlavorVec hL      = FlavorVec(1, INF);
+	FlavorVec hT      = FlavorVec(1, INF);
+	FlavorVec hTperp  = FlavorVec(1, INF);
 	/// \}
 
 	/// \name Variances of FFs
 	/// \{
-	FlavorVec D1;
-	FlavorVec H1perp;
+	FlavorVec D1      = FlavorVec(1, INF);
+	FlavorVec H1perp  = FlavorVec(1, INF);
 	/// \}
 
 	/// Initializes the variances. Each variance is set to be infinity by
 	/// default, which means the corresponding TMD will be completely neglected.
-	explicit GaussianWwTmdVars();
+	GaussianWwTmdVars() { }
 };
 
 /**

--- a/include/sidis/tmd.hpp
+++ b/include/sidis/tmd.hpp
@@ -1,8 +1,7 @@
 #ifndef SIDIS_TMD_HPP
 #define SIDIS_TMD_HPP
 
-#include <vector>
-
+#include "sidis/flavor_vec.hpp"
 #include "sidis/particle.hpp"
 
 namespace sidis {
@@ -27,63 +26,116 @@ class TmdSet {
 public:
 	/// The number of flavors supported by the TmdSet.
 	unsigned const flavor_count;
+	/// The charges of each flavor.
+	FlavorVec const charges;
 	/// What type of part::Nucleus the TMDs are valid for.
 	part::Nucleus const target;
 
 	/// Initialize a TMDSet with \p flavor_count number of flavors and for the
 	/// specified target.
-	TmdSet(unsigned flavor_count, part::Nucleus target) :
-		flavor_count(flavor_count),
-		target(target) { }
+	TmdSet(unsigned flavor_count, FlavorVec const& charges, part::Nucleus target);
 	TmdSet(TmdSet const&) = delete;
 	TmdSet(TmdSet&&) = delete;
 	TmdSet& operator=(TmdSet const&) = delete;
 	TmdSet& operator=(TmdSet&&) = delete;
 	virtual ~TmdSet() = default;
 
-	/// Charge of a given flavor (for use as the weighting when computing
-	/// structure functions).
-	virtual Real charge(unsigned fl) const = 0;
-
 	/// \name Transverse momentum distributions
 	/// By default, these return zero.
 	/// \{
-	virtual Real xf1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xf1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xfT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xfperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xfLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xfTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xg1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xg1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xgT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xgperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xgLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xgTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xh1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xh1perp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xh1Lperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xh1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xh(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xhL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xhT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xhTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xe(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xeL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xeT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	virtual Real xeTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xf1(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xf1Tperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xfT(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xfperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xfLperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xfTperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xg1(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xg1Tperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xgT(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xgperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xgLperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xgTperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xh1(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xh1perp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xh1Lperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xh1Tperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xh(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xhL(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xhT(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xhTperp(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xe(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xeL(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xeT(Real x, Real Q_sq, Real k_perp_sq) const;
+	virtual FlavorVec xeTperp(Real x, Real Q_sq, Real k_perp_sq) const;
 	/// \}
 
 	/// \name Fragmentation functions
 	/// By default, these return zero.
 	/// \{
-	virtual Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const;
-	virtual Real H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const;
-	virtual Real Dperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const;
-	virtual Real H_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const;
-	virtual Real Gperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const;
-	virtual Real E_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const;
+	virtual FlavorVec D1(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const;          // XX
+	virtual FlavorVec H1perp(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const;      // XX
+	virtual FlavorVec Dperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const; // UU UT LL LT
+	virtual FlavorVec H_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const;     // UX
+	virtual FlavorVec Gperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const; // UL UT LU LT
+	virtual FlavorVec E_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const;     // LX
 	/// \}
+};
+
+struct GaussianWwTmdVars;
+
+/**
+ * Stores the width of the Gaussian TMDs and FFs, for use in GaussianTmdSet.
+ * Technically, the square of the width (equivalent to the variance) is stored.
+ * The variances can be be specified by flavor.
+ *
+ * \sa GaussianTmdSet
+ * \sa GaussianWwTmdVars
+ */
+struct GaussianTmdVars {
+	/// \name Variances of TMDs
+	/// \{
+	FlavorVec f1;
+	FlavorVec f1Tperp;
+	FlavorVec fT;
+	FlavorVec fperp;
+	FlavorVec fLperp;
+	FlavorVec fTperp;
+	FlavorVec g1;
+	FlavorVec g1Tperp;
+	FlavorVec gT;
+	FlavorVec gperp;
+	FlavorVec gLperp;
+	FlavorVec gTperp;
+	FlavorVec h1;
+	FlavorVec h1perp;
+	FlavorVec h1Lperp;
+	FlavorVec h1Tperp;
+	FlavorVec h;
+	FlavorVec hL;
+	FlavorVec hT;
+	FlavorVec hTperp;
+	FlavorVec e;
+	FlavorVec eL;
+	FlavorVec eT;
+	FlavorVec eTperp;
+	/// \}
+
+	/// \name Variances of FFs
+	/// \{
+	FlavorVec D1;
+	FlavorVec H1perp;
+	FlavorVec Dperp_tilde;
+	FlavorVec H_tilde;
+	FlavorVec Gperp_tilde;
+	FlavorVec E_tilde;
+	/// \}
+
+	/// Initializes the variances. Each variance is set to be infinity by
+	/// default, which means the corresponding TMD will be completely neglected.
+	explicit GaussianTmdVars();
+	/// Initializes the variances using the variances for the Wandzura-Wilczek
+	/// base set of TMDs and FFs.
+	explicit GaussianTmdVars(GaussianWwTmdVars const& ww_vars);
 };
 
 /**
@@ -93,192 +145,96 @@ public:
  */
 class GaussianTmdSet : public TmdSet {
 public:
-	/// \name Gaussian widths of TMDs
-	/// \{
-	std::vector<Real> const mean_f1;
-	std::vector<Real> const mean_f1Tperp;
-	std::vector<Real> const mean_fT;
-	std::vector<Real> const mean_fperp;
-	std::vector<Real> const mean_fLperp;
-	std::vector<Real> const mean_fTperp;
-	std::vector<Real> const mean_g1;
-	std::vector<Real> const mean_g1Tperp;
-	std::vector<Real> const mean_gT;
-	std::vector<Real> const mean_gperp;
-	std::vector<Real> const mean_gLperp;
-	std::vector<Real> const mean_gTperp;
-	std::vector<Real> const mean_h1;
-	std::vector<Real> const mean_h1perp;
-	std::vector<Real> const mean_h1Lperp;
-	std::vector<Real> const mean_h1Tperp;
-	std::vector<Real> const mean_h;
-	std::vector<Real> const mean_hL;
-	std::vector<Real> const mean_hT;
-	std::vector<Real> const mean_hTperp;
-	std::vector<Real> const mean_e;
-	std::vector<Real> const mean_eL;
-	std::vector<Real> const mean_eT;
-	std::vector<Real> const mean_eTperp;
-	/// \}
+	/// Gaussian variances for each TMD.
+	GaussianTmdVars const vars;
 
-	/// \name Gaussian widths of FFs
-	/// \{
-	std::vector<Real> const mean_D1;
-	std::vector<Real> const mean_H1perp;
-	std::vector<Real> const mean_Dperp_tilde;
-	std::vector<Real> const mean_H_tilde;
-	std::vector<Real> const mean_Gperp_tilde;
-	std::vector<Real> const mean_E_tilde;
-	/// \}
-
-	/// Initialize a GaussianTmdSet with the provided Gaussian widths.
+	/// Initialize a GaussianTmdSet with the provided Gaussian variances
+	/// \p vars.
 	GaussianTmdSet(
 		unsigned flavor_count,
+		FlavorVec const& charges,
 		part::Nucleus target,
-		Real mean_f1,
-		Real mean_f1Tperp,
-		Real mean_fT,
-		Real mean_fperp,
-		Real mean_fLperp,
-		Real mean_fTperp,
-		Real mean_g1,
-		Real mean_g1Tperp,
-		Real mean_gT,
-		Real mean_gperp,
-		Real mean_gLperp,
-		Real mean_gTperp,
-		Real mean_h1,
-		Real mean_h1perp,
-		Real mean_h1Lperp,
-		Real mean_h1Tperp,
-		Real mean_h,
-		Real mean_hL,
-		Real mean_hT,
-		Real mean_hTperp,
-		Real mean_e,
-		Real mean_eL,
-		Real mean_eT,
-		Real mean_eTperp,
-		Real mean_D1,
-		Real mean_H1perp,
-		Real mean_Dperp_tilde,
-		Real mean_H_tilde,
-		Real mean_Gperp_tilde,
-		Real mean_E_tilde);
-	/// Initialize a GaussianTmdSet with the provided flavor-dependent widths.
-	GaussianTmdSet(
-		unsigned flavor_count,
-		part::Nucleus target,
-		Real const* mean_f1,
-		Real const* mean_f1Tperp,
-		Real const* mean_fT,
-		Real const* mean_fperp,
-		Real const* mean_fLperp,
-		Real const* mean_fTperp,
-		Real const* mean_g1,
-		Real const* mean_g1Tperp,
-		Real const* mean_gT,
-		Real const* mean_gperp,
-		Real const* mean_gLperp,
-		Real const* mean_gTperp,
-		Real const* mean_h1,
-		Real const* mean_h1perp,
-		Real const* mean_h1Lperp,
-		Real const* mean_h1Tperp,
-		Real const* mean_h,
-		Real const* mean_hL,
-		Real const* mean_hT,
-		Real const* mean_hTperp,
-		Real const* mean_e,
-		Real const* mean_eL,
-		Real const* mean_eT,
-		Real const* mean_eTperp,
-		Real const* mean_D1,
-		Real const* mean_H1perp,
-		Real const* mean_Dperp_tilde,
-		Real const* mean_H_tilde,
-		Real const* mean_Gperp_tilde,
-		Real const* mean_E_tilde);
+		GaussianTmdVars const& vars);
 	virtual ~GaussianTmdSet() = default;
 
 	/// \name Reduced transverse momentum distributions
 	/// These TMDs do not have explicit \f$\pmb{k}_{\perp}\f$ dependence, since
 	/// the \f$\pmb{k}_{\perp}\f$ dependence is given by the Gaussian widths.
 	/// \{
-	virtual Real xf1(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xf1Tperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xfT(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xfperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xfLperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xfTperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xg1(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xg1Tperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xgT(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xgperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xgLperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xgTperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xh1(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xh1perp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xh1Lperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xh1Tperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xh(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xhL(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xhT(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xhTperp(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xe(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xeL(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xeT(unsigned fl, Real x, Real Q_sq) const;
-	virtual Real xeTperp(unsigned fl, Real x, Real Q_sq) const;
+	virtual FlavorVec xf1(Real x, Real Q_sq) const;
+	virtual FlavorVec xf1Tperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xfT(Real x, Real Q_sq) const;
+	virtual FlavorVec xfperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xfLperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xfTperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xg1(Real x, Real Q_sq) const;
+	virtual FlavorVec xg1Tperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xgT(Real x, Real Q_sq) const;
+	virtual FlavorVec xgperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xgLperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xgTperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xh1(Real x, Real Q_sq) const;
+	virtual FlavorVec xh1perp(Real x, Real Q_sq) const;
+	virtual FlavorVec xh1Lperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xh1Tperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xh(Real x, Real Q_sq) const;
+	virtual FlavorVec xhL(Real x, Real Q_sq) const;
+	virtual FlavorVec xhT(Real x, Real Q_sq) const;
+	virtual FlavorVec xhTperp(Real x, Real Q_sq) const;
+	virtual FlavorVec xe(Real x, Real Q_sq) const;
+	virtual FlavorVec xeL(Real x, Real Q_sq) const;
+	virtual FlavorVec xeT(Real x, Real Q_sq) const;
+	virtual FlavorVec xeTperp(Real x, Real Q_sq) const;
 	/// \}
 
 	/// \name Reduced fragmentation functions
 	/// These FFs do not have explicit \f$\pmb{P}_{\perp}\f$ dependence, since
 	/// the \f$\pmb{P}_{\perp}\f$ dependence is given by the Gaussian widths.
 	/// \{
-	virtual Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
-	virtual Real H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
-	virtual Real Dperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
-	virtual Real H_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
-	virtual Real Gperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
-	virtual Real E_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const;
+	virtual FlavorVec D1(part::Hadron h, Real z, Real Q_sq) const;
+	virtual FlavorVec H1perp(part::Hadron h, Real z, Real Q_sq) const;
+	virtual FlavorVec Dperp_tilde(part::Hadron h, Real z, Real Q_sq) const;
+	virtual FlavorVec H_tilde(part::Hadron h, Real z, Real Q_sq) const;
+	virtual FlavorVec Gperp_tilde(part::Hadron h, Real z, Real Q_sq) const;
+	virtual FlavorVec E_tilde(part::Hadron h, Real z, Real Q_sq) const;
 	/// \}
 
 	/// \name Transverse momentum distributions
 	/// \{
-	Real xf1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xf1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xg1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xg1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xh1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xh1perp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xh1Lperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xh1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xh(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xhL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xhT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xhTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xe(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xeL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xeT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xeTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xf1(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xf1Tperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfLperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xg1(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xg1Tperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgLperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xh1(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xh1perp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xh1Lperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xh1Tperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xh(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xhL(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xhT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xhTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xe(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xeL(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xeT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xeTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
 	/// \}
 
 	/// \name Fragmentation functions
 	/// \{
-	Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real Dperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real H_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real Gperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real E_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec D1(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec H1perp(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec Dperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec H_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec Gperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec E_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
 	/// \}
 };
 
@@ -294,75 +250,111 @@ public:
 	/// specified target.
 	WwTmdSet(
 		unsigned flavor_count,
+		FlavorVec const& charges,
 		part::Nucleus target) :
-		TmdSet(
-			flavor_count,
-			target) { }
+		TmdSet(flavor_count, charges, target) { }
 	virtual ~WwTmdSet() = default;
 
 	/// \name Base set of transverse momentum distributions
 	/// By default, these return zero.
 	/// \{
-	virtual Real xf1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xf1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xg1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xg1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xh1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xh1perp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xh1Lperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	virtual Real xh1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xf1(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xf1Tperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xg1(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xg1Tperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xh1(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xh1perp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xh1Lperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	virtual FlavorVec xh1Tperp(Real x, Real Q_sq, Real k_perp_sq) const override;
 	/// \}
 
 	/// \name Base set of fragmentation functions
 	/// By default, these return zero.
 	/// \{
-	virtual Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	virtual Real H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
+	virtual FlavorVec D1(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	virtual FlavorVec H1perp(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
 	/// \}
 
 	/// \name Transverse momentum distribution moments
 	/// Important first moments of TMDs.
 	/// \{
-	Real xf1TperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	Real xg1TperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	Real xh1perpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	Real xh1LperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
-	Real xh1TperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const;
+	FlavorVec xf1TperpM1(Real x, Real Q_sq, Real k_perp_sq) const;
+	FlavorVec xg1TperpM1(Real x, Real Q_sq, Real k_perp_sq) const;
+	FlavorVec xh1perpM1(Real x, Real Q_sq, Real k_perp_sq) const;
+	FlavorVec xh1LperpM1(Real x, Real Q_sq, Real k_perp_sq) const;
+	FlavorVec xh1TperpM1(Real x, Real Q_sq, Real k_perp_sq) const;
 	/// \}
 
 	/// \name Transverse momentum distributions
 	/// \{
-	Real xfT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xfTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xgTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xh(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xhL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xhT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xhTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xe(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xeL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xeT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
-	Real xeTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfLperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xfTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgLperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xgTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xh(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xhL(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xhT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xhTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xe(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xeL(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xeT(Real x, Real Q_sq, Real k_perp_sq) const override;
+	FlavorVec xeTperp(Real x, Real Q_sq, Real k_perp_sq) const override;
 	/// \}
 
 	/// \name Fragmentation functions
 	/// \{
-	Real Dperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real H_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real Gperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
-	Real E_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec Dperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec H_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec Gperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
+	FlavorVec E_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const override;
 	/// \}
+};
+
+/**
+ * Similar to GaussianTmdVars, but only for the subset of TMDs and FFs needed in
+ * the Wandzura-Wilczek-type approximation.
+ *
+ * \sa GaussianWwTmdSet
+ * \sa GaussianTmdVars
+ */
+struct GaussianWwTmdVars {
+	/// \name Variances of TMDs
+	/// \{
+	FlavorVec f1;
+	FlavorVec f1Tperp;
+	FlavorVec fT;
+	FlavorVec g1;
+	FlavorVec g1Tperp;
+	FlavorVec gT;
+	FlavorVec h1;
+	FlavorVec h1perp;
+	FlavorVec h1Lperp;
+	FlavorVec h1Tperp;
+	FlavorVec h;
+	FlavorVec hL;
+	FlavorVec hT;
+	FlavorVec hTperp;
+	/// \}
+
+	/// \name Variances of FFs
+	/// \{
+	FlavorVec D1;
+	FlavorVec H1perp;
+	/// \}
+
+	/// Initializes the variances. Each variance is set to be infinity by
+	/// default, which means the corresponding TMD will be completely neglected.
+	explicit GaussianWwTmdVars();
 };
 
 /**
  * Combine Gaussian and WW-type approximations together. Because of some
  * inconsistencies between Gaussian and WW-type approximations, the method of
- * combining these two (take from \cite bastami2019ww) is to first apply the
+ * combining these two (taken from \cite bastami2019ww) is to first apply the
  * Gaussian approximation when performing convolutions, and then to apply the
  * WW-type approximation to the reduced TMDs and FFs without
  * \f$\pmb{k}_{\perp}\f$ or \f$\pmb{P}_{\perp}\f$ dependence.
@@ -371,105 +363,71 @@ public:
  */
 class GaussianWwTmdSet : public GaussianTmdSet {
 public:
-	/// Initialize a GaussianWwTmdSet with the provided Gaussian widths.
+	/// Initialize a GaussianWwTmdSet with the provided Gaussian variances.
 	GaussianWwTmdSet(
 		unsigned flavor_count,
+		FlavorVec const& charges,
 		part::Nucleus target,
-		Real mean_f1,
-		Real mean_f1Tperp,
-		Real mean_fT,
-		Real mean_g1,
-		Real mean_g1Tperp,
-		Real mean_gT,
-		Real mean_h1,
-		Real mean_h1perp,
-		Real mean_h1Lperp,
-		Real mean_h1Tperp,
-		Real mean_h,
-		Real mean_hL,
-		Real mean_hT,
-		Real mean_hTperp,
-		Real mean_D1,
-		Real mean_H1perp);
-	/// Initialize a GaussianWwTmdSet with the provided flavor-dependent widths.
-	GaussianWwTmdSet(
-		unsigned flavor_count,
-		part::Nucleus target,
-		Real const* mean_f1,
-		Real const* mean_f1Tperp,
-		Real const* mean_fT,
-		Real const* mean_g1,
-		Real const* mean_g1Tperp,
-		Real const* mean_gT,
-		Real const* mean_h1,
-		Real const* mean_h1perp,
-		Real const* mean_h1Lperp,
-		Real const* mean_h1Tperp,
-		Real const* mean_h,
-		Real const* mean_hL,
-		Real const* mean_hT,
-		Real const* mean_hTperp,
-		Real const* mean_D1,
-		Real const* mean_H1perp);
+		GaussianWwTmdVars const& vars);
 	virtual ~GaussianWwTmdSet() = default;
 
 	/// \name Base set of reduced transverse momentum distributions
 	/// These TMDs do not have explicit \f$\pmb{k}_{\perp}\f$ dependence, since
 	/// the \f$\pmb{k}_{\perp}\f$ dependence is given by the Gaussian widths.
 	/// \{
-	virtual Real xf1(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xf1Tperp(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xg1(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xg1Tperp(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xh1(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xh1perp(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xh1Lperp(unsigned fl, Real x, Real Q_sq) const override;
-	virtual Real xh1Tperp(unsigned fl, Real x, Real Q_sq) const override;
+	virtual FlavorVec xf1(Real x, Real Q_sq) const override;
+	virtual FlavorVec xf1Tperp(Real x, Real Q_sq) const override;
+	virtual FlavorVec xg1(Real x, Real Q_sq) const override;
+	virtual FlavorVec xg1Tperp(Real x, Real Q_sq) const override;
+	virtual FlavorVec xh1(Real x, Real Q_sq) const override;
+	virtual FlavorVec xh1perp(Real x, Real Q_sq) const override;
+	virtual FlavorVec xh1Lperp(Real x, Real Q_sq) const override;
+	virtual FlavorVec xh1Tperp(Real x, Real Q_sq) const override;
 	/// \}
 
 	/// \name Base set of reduced fragmentation functions
 	/// These FFs do not have explicit \f$\pmb{P}_{\perp}\f$ dependence, since
 	/// the \f$\pmb{P}_{\perp}\f$ dependence is given by the Gaussian widths.
 	/// \{
-	virtual Real D1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
-	virtual Real H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
+	virtual FlavorVec D1(part::Hadron h, Real z, Real Q_sq) const override;
+	virtual FlavorVec H1perp(part::Hadron h, Real z, Real Q_sq) const override;
 	/// \}
 
 	/// \name Transverse momentum distribution moments
 	/// Important reduced first moments of TMDs.
 	/// \{
-	Real xf1TperpM1(unsigned fl, Real x, Real Q_sq) const;
-	Real xg1TperpM1(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1perpM1(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1LperpM1(unsigned fl, Real x, Real Q_sq) const;
-	Real xh1TperpM1(unsigned fl, Real x, Real Q_sq) const;
+	FlavorVec xf1TperpM1(Real x, Real Q_sq) const;
+	FlavorVec xg1TperpM1(Real x, Real Q_sq) const;
+	FlavorVec xh1perpM1(Real x, Real Q_sq) const;
+	FlavorVec xh1LperpM1(Real x, Real Q_sq) const;
+	FlavorVec xh1TperpM1(Real x, Real Q_sq) const;
 
 	/// Transverse momentum distributions
 	/// \{
-	Real xfT(unsigned fl, Real x, Real Q_sq) const override;
-	Real xfperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xfLperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xfTperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xgT(unsigned fl, Real x, Real Q_sq) const override;
-	Real xgperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xgLperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xgTperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xh(unsigned fl, Real x, Real Q_sq) const override;
-	Real xhL(unsigned fl, Real x, Real Q_sq) const override;
-	Real xhT(unsigned fl, Real x, Real Q_sq) const override;
-	Real xhTperp(unsigned fl, Real x, Real Q_sq) const override;
-	Real xe(unsigned fl, Real x, Real Q_sq) const override;
-	Real xeL(unsigned fl, Real x, Real Q_sq) const override;
-	Real xeT(unsigned fl, Real x, Real Q_sq) const override;
-	Real xeTperp(unsigned fl, Real x, Real Q_sq) const override;
+	FlavorVec xfT(Real x, Real Q_sq) const override;
+	FlavorVec xfperp(Real x, Real Q_sq) const override;
+	FlavorVec xfLperp(Real x, Real Q_sq) const override;
+	FlavorVec xfTperp(Real x, Real Q_sq) const override;
+	FlavorVec xgT(Real x, Real Q_sq) const override;
+	FlavorVec xgperp(Real x, Real Q_sq) const override;
+	FlavorVec xgLperp(Real x, Real Q_sq) const override;
+	FlavorVec xgTperp(Real x, Real Q_sq) const override;
+	FlavorVec xh(Real x, Real Q_sq) const override;
+	FlavorVec xhL(Real x, Real Q_sq) const override;
+	FlavorVec xhT(Real x, Real Q_sq) const override;
+	FlavorVec xhTperp(Real x, Real Q_sq) const override;
+	FlavorVec xe(Real x, Real Q_sq) const override;
+	FlavorVec xeL(Real x, Real Q_sq) const override;
+	FlavorVec xeT(Real x, Real Q_sq) const override;
+	FlavorVec xeTperp(Real x, Real Q_sq) const override;
 	/// \}
 
 	/// Fragmentation functions
 	/// \{
-	Real Dperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
-	Real H_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
-	Real Gperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
-	Real E_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq) const override;
+	FlavorVec Dperp_tilde(part::Hadron h, Real z, Real Q_sq) const override;
+	FlavorVec H_tilde(part::Hadron h, Real z, Real Q_sq) const override;
+	FlavorVec Gperp_tilde(part::Hadron h, Real z, Real Q_sq) const override;
+	FlavorVec E_tilde(part::Hadron h, Real z, Real Q_sq) const override;
 	/// \}
 };
 /// \}

--- a/include/sidis/tmd.hpp
+++ b/include/sidis/tmd.hpp
@@ -25,16 +25,16 @@ namespace sf {
  */
 class TmdSet {
 public:
+	/// What type of part::Nucleus the TMDs are valid for.
+	part::Nucleus const target;
 	/// The number of flavors supported by the TmdSet.
 	unsigned const flavor_count;
 	/// The charges of each flavor.
 	FlavorVec const charges;
-	/// What type of part::Nucleus the TMDs are valid for.
-	part::Nucleus const target;
 
 	/// Initialize a TMDSet with \p flavor_count number of flavors and for the
 	/// specified target.
-	TmdSet(unsigned flavor_count, FlavorVec const& charges, part::Nucleus target);
+	TmdSet(part::Nucleus target, unsigned flavor_count, FlavorVec const& charges);
 	TmdSet(TmdSet const&) = delete;
 	TmdSet(TmdSet&&) = delete;
 	TmdSet& operator=(TmdSet const&) = delete;
@@ -152,9 +152,9 @@ public:
 	/// Initialize a GaussianTmdSet with the provided Gaussian variances
 	/// \p vars.
 	GaussianTmdSet(
+		part::Nucleus target,
 		unsigned flavor_count,
 		FlavorVec const& charges,
-		part::Nucleus target,
 		GaussianTmdVars const& vars);
 	virtual ~GaussianTmdSet() = default;
 
@@ -253,7 +253,7 @@ public:
 		unsigned flavor_count,
 		FlavorVec const& charges,
 		part::Nucleus target) :
-		TmdSet(flavor_count, charges, target) { }
+		TmdSet(target, flavor_count, charges) { }
 	virtual ~WwTmdSet() = default;
 
 	/// \name Base set of transverse momentum distributions
@@ -366,9 +366,9 @@ class GaussianWwTmdSet : public GaussianTmdSet {
 public:
 	/// Initialize a GaussianWwTmdSet with the provided Gaussian variances.
 	GaussianWwTmdSet(
+		part::Nucleus target,
 		unsigned flavor_count,
 		FlavorVec const& charges,
-		part::Nucleus target,
 		GaussianWwTmdVars const& vars);
 	virtual ~GaussianWwTmdSet() = default;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
 	"sidis/constant.hpp"
 	"sidis/cross_section.hpp"
 	"sidis/cut.hpp"
+	"sidis/flavor_vec.hpp"
 	"sidis/frame.hpp"
 	"sidis/hadronic_coeff.hpp"
 	"sidis/integ_params.hpp"
@@ -54,6 +55,7 @@ add_library(
 	cross_section.cpp
 	cut.cpp
 	exception.cpp
+	flavor_vec.cpp
 	frame.cpp
 	hadronic_coeff.cpp
 	kinematics.cpp

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -30,7 +30,7 @@ using namespace sidis::xs;
 // Macro that computes the cross-section from the base cross-sections in an
 // optimized way. For example, if the polarization is zero, then the
 // cross-section can be computed just using the UU base cross-section.
-#define SIDIS_MACRO_XS_FROM_BASE(name, Lep, Had, kin, sf, b, lambda_e, eta) ([&]() { \
+#define XS_FROM_BASE(name, Lep, Had, kin, sf, b, lambda_e, eta) ([&]() { \
 	/* Create a mask describing the polarization state. */ \
 	unsigned pol_mask = (((lambda_e) != 0.) << 3) \
 		| (((eta).x != 0.) << 2) \
@@ -201,10 +201,9 @@ using namespace sidis::xs;
 	return uu + dot(up, (eta)) + (lambda_e)*(lu + dot(lp, (eta))); \
 }())
 
-// Similar to `SIDIS_MACRO_XS_FROM_BASE`, except this one works with base cross-
-// sections where the XL, XT1, and XT2 cases are all grouped together into an
-// XP case.
-#define SIDIS_MACRO_XS_FROM_BASE_P(name, Lep, Had, kin, sf, b, lambda_e, eta) ([&]() { \
+// Similar to `XS_FROM_BASE`, except this one works with base cross-sections
+// where the XL, XT1, and XT2 cases are all grouped together into an XP case.
+#define XS_FROM_BASE_P(name, Lep, Had, kin, sf, b, lambda_e, eta) ([&]() { \
 	/* Create a mask describing the polarization state. */ \
 	unsigned pol_mask = (((lambda_e) != 0.) << 1) \
 		| (((eta).x != 0. || (eta).y != 0. || (eta).z != 0.) << 0); \
@@ -250,10 +249,9 @@ using namespace sidis::xs;
 	return uu + dot(up, (eta)) + (lambda_e)*(lu + dot(lp, (eta))); \
 }())
 
-// This variant of `SIDIS_MACRO_XS_FROM_BASE_P` allows for an "endpoint" set of
-// structure functions to be provided, for endpoint-subtraction-related
-// calculations.
-#define SIDIS_MACRO_XS_FROM_BASE_P_0(name, Lep, Had, kin, sf, had_0, b, lambda_e, eta) ([&]() { \
+// This variant of `XS_FROM_BASE_P` allows for an "endpoint" set of structure
+// functions to be provided, for endpoint-subtraction-related calculations.
+#define XS_FROM_BASE_P_0(name, Lep, Had, kin, sf, had_0, b, lambda_e, eta) ([&]() { \
 	/* Create a mask describing the polarization state. */ \
 	unsigned pol_mask = (((lambda_e) != 0.) << 1) \
 		| (((eta).x != 0. || (eta).y != 0. || (eta).z != 0.) << 0); \
@@ -360,27 +358,27 @@ Real delta_vert_rad_0(Kinematics const& kin) {
 
 Real xs::born(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
 	Born b(kin, phenom);
-	return SIDIS_MACRO_XS_FROM_BASE(born, LepBorn, Had, kin, sf, b, lambda_e, eta);
+	return XS_FROM_BASE(born, LepBorn, Had, kin, sf, b, lambda_e, eta);
 }
 
 Real xs::amm(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
 	Amm b(kin, phenom);
-	return SIDIS_MACRO_XS_FROM_BASE(amm, LepAmm, Had, kin, sf, b, lambda_e, eta);
+	return XS_FROM_BASE(amm, LepAmm, Had, kin, sf, b, lambda_e, eta);
 }
 
 Real xs::nrad_ir(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar) {
 	Nrad b(kin, phenom, k_0_bar);
-	return SIDIS_MACRO_XS_FROM_BASE(nrad_ir, LepNrad, Had, kin, sf, b, lambda_e, eta);
+	return XS_FROM_BASE(nrad_ir, LepNrad, Had, kin, sf, b, lambda_e, eta);
 }
 
 Real xs::rad(KinematicsRad const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
 	Rad b(kin, phenom);
-	return SIDIS_MACRO_XS_FROM_BASE_P(rad, LepRad, HadRad, kin, sf, b, lambda_e, eta);
+	return XS_FROM_BASE_P(rad, LepRad, HadRad, kin, sf, b, lambda_e, eta);
 }
 
 Real xs::rad_f(KinematicsRad const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta) {
 	Rad b(kin, phenom);
-	return SIDIS_MACRO_XS_FROM_BASE_P(rad_f, LepRad, HadRadF, kin, sf, b, lambda_e, eta);
+	return XS_FROM_BASE_P(rad_f, LepRad, HadRadF, kin, sf, b, lambda_e, eta);
 }
 
 EstErr xs::nrad_integ(Kinematics const& kin, Phenom const& phenom, SfSet const& sf, Real lambda_e, Vec3 eta, Real k_0_bar, IntegParams params) {
@@ -405,7 +403,7 @@ EstErr xs::rad_f_integ(Kinematics const& kin, Phenom const& phenom, SfSet const&
 				return 0.;
 			}
 			Rad b(kin_rad, phenom);
-			Real xs = jac * SIDIS_MACRO_XS_FROM_BASE_P_0(rad_f, LepRad, HadRadF, kin_rad, sf, had_0, b, lambda_e, eta);
+			Real xs = jac * XS_FROM_BASE_P_0(rad_f, LepRad, HadRadF, kin_rad, sf, had_0, b, lambda_e, eta);
 			if (std::isnan(xs)) {
 				// If the result is `NaN`, it most likely means we went out of
 				// the allowed region for the structure function grids (or we
@@ -433,7 +431,7 @@ EstErr xs::rad_integ(Kinematics const& kin, Phenom const& phenom, SfSet const& s
 				return 0.;
 			}
 			Rad b(kin_rad, phenom);
-			Real xs = jac * SIDIS_MACRO_XS_FROM_BASE_P(rad, LepRad, HadRad, kin_rad, sf, b, lambda_e, eta);
+			Real xs = jac * XS_FROM_BASE_P(rad, LepRad, HadRad, kin_rad, sf, b, lambda_e, eta);
 			if (std::isnan(xs)) {
 				return 0.;
 			} else {

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -40,6 +40,16 @@ FlavorOutOfRange::FlavorOutOfRange(unsigned flavor) :
 		+ " is out of range for TMD"),
 	flavor(flavor) { }
 
+FlavorVecUnexpectedSize::FlavorVecUnexpectedSize(
+	unsigned size,
+	unsigned expected_size) :
+	_what(
+		"FlavorVec of size " + std::to_string(size)
+		+ " but needed size " + std::to_string(expected_size)
+		+ " for TMD"),
+	size(size),
+	expected_size(expected_size) { }
+
 HadronOutOfRange::HadronOutOfRange(part::Hadron hadron) :
 	_what(
 		std::string("Hadron '") + part::name(hadron)

--- a/src/flavor_vec.cpp
+++ b/src/flavor_vec.cpp
@@ -49,7 +49,7 @@ FlavorVec sf::pow_vec(FlavorVec lhs, Real rhs) {
 	for (unsigned fl = 0; fl < lhs.size(); ++fl) {
 		lhs[fl] = std::pow(lhs[fl], rhs);
 	}
-	return rhs;
+	return lhs;
 }
 FlavorVec sf::pow_vec(FlavorVec lhs, FlavorVec const& rhs) {
 	for (unsigned fl = 0; fl < lhs.size(); ++fl) {

--- a/src/flavor_vec.cpp
+++ b/src/flavor_vec.cpp
@@ -1,0 +1,64 @@
+#include "sidis/tmd.hpp"
+
+#include <cmath>
+#include <initializer_list>
+
+#include "sidis/extra/exception.hpp"
+
+using namespace sidis;
+using namespace sidis::sf;
+
+void FlavorVec::raise_out_of_range(unsigned size) const {
+	throw FlavorOutOfRange(size);
+}
+
+FlavorVec::FlavorVec(std::initializer_list<Real> list) {
+	auto size = list.size();
+	if (!(size <= MAX_FLAVOR_VEC_SIZE)) {
+		raise_out_of_range(size);
+	}
+	std::copy(list.begin(), list.end(), _arr);
+	_size = size;
+}
+
+FlavorVec sf::sqrt_vec(FlavorVec vec) {
+	for (unsigned fl = 0; fl < vec.size(); ++fl) {
+		vec[fl] = std::sqrt(vec[fl]);
+	}
+	return vec;
+}
+FlavorVec sf::sq_vec(FlavorVec vec) {
+	for (unsigned fl = 0; fl < vec.size(); ++fl) {
+		vec[fl] = vec[fl]*vec[fl];
+	}
+	return vec;
+}
+FlavorVec sf::exp_vec(FlavorVec vec) {
+	for (unsigned fl = 0; fl < vec.size(); ++fl) {
+		vec[fl] = std::exp(vec[fl]);
+	}
+	return vec;
+}
+FlavorVec sf::pow_vec(Real lhs, FlavorVec rhs) {
+	for (unsigned fl = 0; fl < rhs.size(); ++fl) {
+		rhs[fl] = std::pow(lhs, rhs[fl]);
+	}
+	return rhs;
+}
+FlavorVec sf::pow_vec(FlavorVec lhs, Real rhs) {
+	for (unsigned fl = 0; fl < lhs.size(); ++fl) {
+		lhs[fl] = std::pow(lhs[fl], rhs);
+	}
+	return rhs;
+}
+FlavorVec sf::pow_vec(FlavorVec lhs, FlavorVec const& rhs) {
+	for (unsigned fl = 0; fl < lhs.size(); ++fl) {
+		lhs[fl] = std::pow(lhs[fl], rhs[fl]);
+	}
+	return lhs;
+}
+
+FlavorVec sf::tmd_gaussian_factor(FlavorVec var, Real k_perp_sq) {
+	return exp_vec(-k_perp_sq/var)/(PI*var);
+}
+

--- a/src/sf_set/prokudin.cpp
+++ b/src/sf_set/prokudin.cpp
@@ -144,7 +144,7 @@ GaussianWwTmdVars const TMD_VARS = []() {
 	return vars;
 }();
 
-FlavorVec CHARGES = {
+FlavorVec const CHARGES = {
 	+2./3., // Up.
 	-1./3., // Down.
 	-1./3., // Strange.

--- a/src/sf_set/prokudin.cpp
+++ b/src/sf_set/prokudin.cpp
@@ -304,14 +304,14 @@ struct ProkudinTmdSet::Impl {
 };
 
 ProkudinTmdSet::ProkudinTmdSet() :
-	GaussianWwTmdSet(NUM_FLAVORS, CHARGES, part::Nucleus::P, TMD_VARS),
+	GaussianWwTmdSet(part::Nucleus::P, NUM_FLAVORS, CHARGES, TMD_VARS),
 	_impl(new Impl()) { }
 
 ProkudinTmdSet::ProkudinTmdSet(ProkudinTmdSet&& other) noexcept :
 		// TODO: This should be removed when copy constructors are put back into
 		// `GaussianWwTmdSet`. For now, we are taking advantage of the fact that
 		// all `ProkudinTmdSet`s are constructed in the same way.
-		GaussianWwTmdSet(NUM_FLAVORS, CHARGES, part::Nucleus::P, TMD_VARS),
+		GaussianWwTmdSet(part::Nucleus::P, NUM_FLAVORS, CHARGES, TMD_VARS),
 		_impl(nullptr) {
 	std::swap(_impl, other._impl);
 }

--- a/src/sf_set/prokudin.cpp
+++ b/src/sf_set/prokudin.cpp
@@ -41,7 +41,7 @@ Real const D1_MEAN_P_PERP_SQ = 0.2;
 // Parameters for transversity.
 Real const H1_ALPHA = 1.11;
 Real const H1_BETA = 3.64;
-Real const H1_N[6] = {
+FlavorVec const H1_N = {
 	0.46, -1.00, 0.,
 	0., 0., 0.,
 };
@@ -63,15 +63,15 @@ Real const COLLINS_MEAN_P_PERP_SQ = (D1_MEAN_P_PERP_SQ * COLLINS_M_SQ)
 // Parameters for Sivers.
 Real const SIVERS_M_1_SQ = 0.19;
 Real const SIVERS_M_1 = std::sqrt(SIVERS_M_1_SQ);
-Real const SIVERS_ALPHA[6] = {
+FlavorVec const SIVERS_ALPHA = {
 	0.35, 0.44, 0.,
 	0., 0., 0.,
 };
-Real const SIVERS_BETA[6] = {
+FlavorVec const SIVERS_BETA = {
 	2.6, 0.90, 0.,
 	0., 0., 0.,
 };
-Real const SIVERS_N[6] = {
+FlavorVec const SIVERS_N = {
 	0.40, -0.97, 0.,
 	0., 0., 0.,
 };
@@ -81,16 +81,19 @@ Real const SIVERS_MEAN_K_PERP_SQ = (F1_MEAN_K_PERP_SQ * SIVERS_M_1_SQ)
 // Parameters for Boer-Mulders.
 Real const BM_M_1_SQ = 0.34;
 Real const BM_M_1 = std::sqrt(BM_M_1_SQ);
-Real const BM_ALPHA[6] = {
+FlavorVec const BM_ALPHA = {
 	0.73, 1.08, 0.79,
 	0.79, 0.79, 0.79,
 };
-Real const BM_BETA = 3.46;
-Real const BM_A[6] = {
+FlavorVec const BM_BETA = {
+	3.46, 3.46, 3.46,
+	3.46, 3.46, 3.46,
+};
+FlavorVec const BM_A = {
 	0.35, -0.90, 0.24,
 	0.04, -0.40, -1.,
 };
-Real const BM_LAMBDA[6] = {
+FlavorVec const BM_LAMBDA = {
 	2.1, -1.111, 0.,
 	0., 0., 0.,
 };
@@ -102,7 +105,7 @@ Real const PRETZ_M_TT_SQ = 0.18;
 Real const PRETZ_M_TT = std::sqrt(PRETZ_M_TT_SQ);
 Real const PRETZ_ALPHA = 2.5;
 Real const PRETZ_BETA = 2.;
-Real const PRETZ_N[6] = {
+FlavorVec const PRETZ_N = {
 	1., -1., 0.,
 	0., 0., 0.,
 };
@@ -116,6 +119,39 @@ Real G(Real ph_t_sq, Real l) {
 Real lambda(Real z, Real mean_kperp_sq, Real mean_pperp_sq) {
 	return sq(z) * mean_kperp_sq + mean_pperp_sq;
 }
+
+// Struct summarizing the TMD Gaussian variances.
+GaussianWwTmdVars const TMD_VARS = []() {
+	GaussianWwTmdVars vars{};
+	vars.f1 = F1_MEAN_K_PERP_SQ;
+	vars.f1Tperp = SIVERS_MEAN_K_PERP_SQ;
+	// vars.fT
+	vars.g1 = G1_MEAN_K_PERP_SQ;
+	vars.g1Tperp = G1_MEAN_K_PERP_SQ;
+	vars.gT = G1_MEAN_K_PERP_SQ;
+	vars.h1 = H1_MEAN_K_PERP_SQ;
+	vars.h1perp = BM_MEAN_K_PERP_SQ;
+	vars.h1Lperp = H1_MEAN_K_PERP_SQ;
+	vars.h1Tperp = PRETZ_MEAN_K_PERP_SQ;
+	// vars.h
+	vars.hL = H1_MEAN_K_PERP_SQ;
+	vars.hT = HT_MEAN_K_PERP_SQ;
+	vars.hTperp = HT_MEAN_K_PERP_SQ;
+	vars.D1 = D1_MEAN_P_PERP_SQ;
+	vars.H1perp = COLLINS_MEAN_P_PERP_SQ;
+	// `fT` and `h` are neglected because of a lack of information about the
+	// `fT` TMD (see the discussion in section 7.6 of [2]).
+	return vars;
+}();
+
+FlavorVec CHARGES = {
+	+2./3., // Up.
+	-1./3., // Down.
+	-1./3., // Strange.
+	-2./3., // Up bar.
+	+1./3., // Down bar.
+	+1./3., // Strange bar.
+};
 
 // Finds a grid file.
 std::istream& find_file(std::ifstream& fin, char const* file_name) {
@@ -164,29 +200,6 @@ std::array<Grid<T, N>, K> load_grids(char const* file_name) {
 	}
 	// By default, assume the grids are only accurate to single precision.
 	return read_grids<T, N, K>(data, 0.000001);
-}
-
-Real charge(unsigned fl) {
-	switch (fl) {
-	// Up.
-	case 0:
-		return 2./3.;
-	// Down.
-	case 1:
-	// Strange.
-	case 2:
-		return -1./3.;
-	// Up bar.
-	case 3:
-		return -2./3.;
-	// Down bar.
-	case 4:
-	// Strange bar.
-	case 5:
-		return 1./3.;
-	default:
-		return 0.;
-	}
 }
 
 // Shared implementation between `ProkudinTmdSet` and `ProkudinSfSet`.
@@ -273,6 +286,17 @@ struct ProkudinImpl {
 	}
 };
 
+FlavorVec eval_interp_arr(const CubicView<Real, 2> (&interp)[6], Real x, Real Q_sq) {
+	return FlavorVec {
+		interp[0]({ (x), (Q_sq) }),
+		interp[1]({ (x), (Q_sq) }),
+		interp[2]({ (x), (Q_sq) }),
+		interp[3]({ (x), (Q_sq) }),
+		interp[4]({ (x), (Q_sq) }),
+		interp[5]({ (x), (Q_sq) }),
+	};
+}
+
 }
 
 struct ProkudinTmdSet::Impl {
@@ -280,64 +304,14 @@ struct ProkudinTmdSet::Impl {
 };
 
 ProkudinTmdSet::ProkudinTmdSet() :
-	GaussianWwTmdSet(
-		NUM_FLAVORS,
-		part::Nucleus::P,
-		// `mean_f1`.
-		F1_MEAN_K_PERP_SQ,
-		// `mean_f1Tperp`.
-		SIVERS_MEAN_K_PERP_SQ,
-		// `mean_fT`. This is neglected because of a lack of information about
-		// the `fT` TMD (see discussion in section 7.6 of [2]).
-		INF,
-		// `mean_g1`.
-		G1_MEAN_K_PERP_SQ,
-		// `mean_g1Tperp`.
-		G1_MEAN_K_PERP_SQ,
-		// `mean_gT`.
-		G1_MEAN_K_PERP_SQ,
-		// `mean_h1`.
-		H1_MEAN_K_PERP_SQ,
-		// `mean_h1perp`.
-		BM_MEAN_K_PERP_SQ,
-		// `mean_h1Lperp`.
-		H1_MEAN_K_PERP_SQ,
-		// `mean_h1Tperp`.
-		PRETZ_MEAN_K_PERP_SQ,
-		// `mean_h`. Neglected similarly to `mean_fT`.
-		INF,
-		// `mean_hL`.
-		H1_MEAN_K_PERP_SQ,
-		// `mean_hT`.
-		HT_MEAN_K_PERP_SQ,
-		// `mean_hTperp`.
-		HT_MEAN_K_PERP_SQ,
-		// `mean_D1`.
-		D1_MEAN_P_PERP_SQ,
-		// `mean_H1perp`.
-		COLLINS_MEAN_P_PERP_SQ),
+	GaussianWwTmdSet(NUM_FLAVORS, CHARGES, part::Nucleus::P, TMD_VARS),
 	_impl(new Impl()) { }
 
 ProkudinTmdSet::ProkudinTmdSet(ProkudinTmdSet&& other) noexcept :
-		GaussianWwTmdSet(
-			other.flavor_count,
-			other.target,
-			other.mean_f1.data(),
-			other.mean_f1Tperp.data(),
-			other.mean_fT.data(),
-			other.mean_g1.data(),
-			other.mean_g1Tperp.data(),
-			other.mean_gT.data(),
-			other.mean_h1.data(),
-			other.mean_h1perp.data(),
-			other.mean_h1Lperp.data(),
-			other.mean_h1Tperp.data(),
-			other.mean_h.data(),
-			other.mean_hL.data(),
-			other.mean_hT.data(),
-			other.mean_hTperp.data(),
-			other.mean_D1.data(),
-			other.mean_H1perp.data()),
+		// TODO: This should be removed when copy constructors are put back into
+		// `GaussianWwTmdSet`. For now, we are taking advantage of the fact that
+		// all `ProkudinTmdSet`s are constructed in the same way.
+		GaussianWwTmdSet(NUM_FLAVORS, CHARGES, part::Nucleus::P, TMD_VARS),
 		_impl(nullptr) {
 	std::swap(_impl, other._impl);
 }
@@ -351,129 +325,115 @@ ProkudinTmdSet::~ProkudinTmdSet() {
 	}
 }
 
-Real ProkudinTmdSet::charge(unsigned fl) const {
-	return ::charge(fl);
-}
-
-Real ProkudinTmdSet::xf1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::xf1(Real x, Real Q_sq) const {
 	Real Q = std::sqrt(Q_sq);
-	switch (fl) {
-	case 0:
-		return _impl->impl.pdf.parton(8, x, Q) + _impl->impl.pdf.parton(-2, x, Q);
-	case 1:
-		return _impl->impl.pdf.parton(7, x, Q) + _impl->impl.pdf.parton(-1, x, Q);
-	case 2:
-		return _impl->impl.pdf.parton(3, x, Q);
-	case 3:
-		return _impl->impl.pdf.parton(-2, x, Q);
-	case 4:
-		return _impl->impl.pdf.parton(-1, x, Q);
-	case 5:
-		return _impl->impl.pdf.parton(-3, x, Q);
-	default:
-		// Although we could throw an exception here, most of the other TMDs are
-		// unchecked, so for consistency we will leave it.
-		return 0.;
-	}
+	return FlavorVec {
+		_impl->impl.pdf.parton(8, x, Q) + _impl->impl.pdf.parton(-2, x, Q),
+		_impl->impl.pdf.parton(7, x, Q) + _impl->impl.pdf.parton(-1, x, Q),
+		_impl->impl.pdf.parton(3, x, Q),
+		_impl->impl.pdf.parton(-2, x, Q),
+		_impl->impl.pdf.parton(-1, x, Q),
+		_impl->impl.pdf.parton(-3, x, Q),
+	};
 }
 
-Real ProkudinTmdSet::xf1Tperp(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::xf1Tperp(Real x, Real Q_sq) const {
 	// Equation [2.A.2].
 	return -std::sqrt(2.*E)*M/SIVERS_M_1
 		*SIVERS_MEAN_K_PERP_SQ/F1_MEAN_K_PERP_SQ
-		*SIVERS_N[fl]
-		*std::pow(x, SIVERS_ALPHA[fl])*std::pow(1. - x, SIVERS_BETA[fl])
-		*std::pow(SIVERS_ALPHA[fl] + SIVERS_BETA[fl],
-			SIVERS_ALPHA[fl] + SIVERS_BETA[fl])
-		*std::pow(SIVERS_ALPHA[fl], -SIVERS_ALPHA[fl])
-		*std::pow(SIVERS_BETA[fl], -SIVERS_BETA[fl])
-		*xf1(fl, x, Q_sq);
+		*SIVERS_N
+		*pow_vec(x, SIVERS_ALPHA)*pow_vec(1. - x, SIVERS_BETA)
+		*pow_vec(SIVERS_ALPHA + SIVERS_BETA, SIVERS_ALPHA + SIVERS_BETA)
+		*pow_vec(SIVERS_ALPHA, -SIVERS_ALPHA)
+		*pow_vec(SIVERS_BETA, -SIVERS_BETA)
+		*xf1(x, Q_sq);
 }
 
-Real ProkudinTmdSet::xg1(unsigned fl, Real x, Real Q_sq) const {
-	return x * _impl->impl.interp_g1[fl]({ x, Q_sq });
+FlavorVec ProkudinTmdSet::xg1(Real x, Real Q_sq) const {
+	return x*eval_interp_arr(_impl->impl.interp_g1, x, Q_sq);
 }
 
-Real ProkudinTmdSet::xg1Tperp(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::xg1Tperp(Real x, Real Q_sq) const {
 	// We only have a grid for `gT`, so use the reverse WW-type approximation to
 	// get `g1Tperp`.
-	return (2.*M*M/G1_MEAN_K_PERP_SQ)*x*_impl->impl.interp_xgT[fl]({ x, Q_sq });
+	return (2.*M*M/G1_MEAN_K_PERP_SQ)*x
+		*eval_interp_arr(_impl->impl.interp_xgT, x, Q_sq);
 }
 
-Real ProkudinTmdSet::xh1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::xh1(Real x, Real Q_sq) const {
 	// Use the Soffer bound to get an upper limit on transversity (Equation
 	// [2.A.7]).
-	return x*H1_N[fl]
+	return x*H1_N
 		*std::pow(x, H1_ALPHA)*std::pow(1. - x, H1_BETA)
 		*std::pow(H1_ALPHA + H1_BETA, H1_ALPHA + H1_BETA)
 		*std::pow(H1_ALPHA, -H1_ALPHA)
 		*std::pow(H1_BETA, -H1_BETA)
-		*_impl->impl.interp_sb[fl]({ x, Q_sq });
+		*eval_interp_arr(_impl->impl.interp_sb, x, Q_sq);
 }
 
-Real ProkudinTmdSet::xh1perp(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::xh1perp(Real x, Real Q_sq) const {
 	// Equation [2.A.18].
 	return -std::sqrt(2.*E)*M/BM_M_1
 		*BM_MEAN_K_PERP_SQ/F1_MEAN_K_PERP_SQ
-		*BM_LAMBDA[fl] * BM_A[fl]
-		*std::pow(x, BM_ALPHA[fl]) * std::pow(1. - x, BM_BETA)
-		*std::pow(BM_ALPHA[fl] + BM_BETA, BM_ALPHA[fl] + BM_BETA)
-		*std::pow(BM_ALPHA[fl], -BM_ALPHA[fl])
-		*std::pow(BM_BETA, -BM_BETA)
-		*xf1(fl, x, Q_sq);
+		*BM_LAMBDA * BM_A
+		*pow_vec(x, BM_ALPHA)*pow_vec(1. - x, BM_BETA)
+		*pow_vec(BM_ALPHA + BM_BETA, BM_ALPHA + BM_BETA)
+		*pow_vec(BM_ALPHA, -BM_ALPHA)
+		*pow_vec(BM_BETA, -BM_BETA)
+		*xf1(x, Q_sq);
 }
 
-Real ProkudinTmdSet::xh1Lperp(unsigned fl, Real x, Real Q_sq) const {
-	if (fl != 0 && fl != 1) {
-		return 0.;
-	} else {
-		return 2.*sq(M)/H1_MEAN_K_PERP_SQ
-			*_impl->impl.interp_xh1LperpM1[fl]({ x, Q_sq });
-	}
+FlavorVec ProkudinTmdSet::xh1Lperp(Real x, Real Q_sq) const {
+	return FlavorVec {
+		2.*sq(M)/H1_MEAN_K_PERP_SQ*_impl->impl.interp_xh1LperpM1[0]({ x, Q_sq }),
+		2.*sq(M)/H1_MEAN_K_PERP_SQ*_impl->impl.interp_xh1LperpM1[1]({ x, Q_sq }),
+		0., 0., 0., 0.,
+	};
 }
 
-Real ProkudinTmdSet::xh1Tperp(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::xh1Tperp(Real x, Real Q_sq) const {
 	// Equation [2.A.24].
 	return E*sq(M)/PRETZ_M_TT_SQ
 		*PRETZ_MEAN_K_PERP_SQ/F1_MEAN_K_PERP_SQ
-		*PRETZ_N[fl]
+		*PRETZ_N
 		*std::pow(x, PRETZ_ALPHA) * std::pow(1. - x, PRETZ_BETA)
 		*std::pow(PRETZ_ALPHA + PRETZ_BETA, PRETZ_ALPHA + PRETZ_BETA)
 		*std::pow(PRETZ_ALPHA, -PRETZ_ALPHA)
 		*std::pow(PRETZ_BETA, -PRETZ_BETA)
-		*(xf1(fl, x, Q_sq) - xg1(fl, x, Q_sq));
+		*(xf1(x, Q_sq) - xg1(x, Q_sq));
 }
 
-Real ProkudinTmdSet::D1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::D1(part::Hadron h, Real z, Real Q_sq) const {
 	switch (h) {
 	case part::Hadron::PI_P:
-		return _impl->impl.interp_D1_pi_plus[fl]({ z, Q_sq });
+		return eval_interp_arr(_impl->impl.interp_D1_pi_plus, z, Q_sq);
 	case part::Hadron::PI_M:
-		return _impl->impl.interp_D1_pi_minus[fl]({ z, Q_sq });
+		return eval_interp_arr(_impl->impl.interp_D1_pi_minus, z, Q_sq);
 	default:
 		throw HadronOutOfRange(h);
 	}
 }
 
-Real ProkudinTmdSet::H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq) const {
+FlavorVec ProkudinTmdSet::H1perp(part::Hadron h, Real z, Real Q_sq) const {
 	Real mh = mass(h);
-	Real collins_coeff = 0.;
+	FlavorVec collins_coeff(6, 0.);
 	// Favored or dis-favored depending on charge of the quark.
-	if (h == part::Hadron::PI_P) {
-		if (fl == 0 || fl == 4) {
-			// Up or anti-down.
-			collins_coeff = COLLINS_N_FAV;
-		} else if (fl == 1 || fl == 3) {
-			// Down or anti-up.
-			collins_coeff = COLLINS_N_DISFAV;
-		}
-	} else if (h == part::Hadron::PI_M) {
-		if (fl == 1 || fl == 3) {
-			collins_coeff = COLLINS_N_FAV;
-		} else if (fl == 0 || fl == 4) {
-			collins_coeff = COLLINS_N_DISFAV;
-		}
-	} else {
+	switch (h) {
+	case part::Hadron::PI_P:
+		// Up or anti-down favored, down or anti-up disfavored.
+		collins_coeff = FlavorVec {
+			COLLINS_N_FAV, COLLINS_N_DISFAV, 0.,
+			COLLINS_N_DISFAV, COLLINS_N_FAV, 0.,
+		};
+		break;
+	case part::Hadron::PI_M:
+		// Opposite.
+		collins_coeff = FlavorVec {
+			COLLINS_N_DISFAV, COLLINS_N_FAV, 0.,
+			COLLINS_N_FAV, COLLINS_N_DISFAV, 0.,
+		};
+		break;
+	default:
 		throw HadronOutOfRange(h);
 	}
 	return std::sqrt(2.*E)*z*mh/COLLINS_M
@@ -483,7 +443,7 @@ Real ProkudinTmdSet::H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq) cons
 		*std::pow(COLLINS_GAMMA + COLLINS_DELTA, COLLINS_GAMMA + COLLINS_DELTA)
 		*std::pow(COLLINS_GAMMA, -COLLINS_GAMMA)
 		*std::pow(COLLINS_DELTA, -COLLINS_DELTA)
-		*D1(h, fl, z, Q_sq);
+		*D1(h, z, Q_sq);
 }
 
 struct ProkudinSfSet::Impl {
@@ -512,10 +472,7 @@ ProkudinSfSet::~ProkudinSfSet() {
 
 Real ProkudinSfSet::F_UUT(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.5.1a].
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xf1(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xf1(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	Real l = lambda(z, F1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return G(ph_t_sq, l)*result;
 }
@@ -523,21 +480,15 @@ Real ProkudinSfSet::F_UU_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Rea
 	// Equation [2.7.9a].
 	Real Q = std::sqrt(Q_sq);
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
 	// Uses a WW-type approximation to rewrite in terms of `xf1`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xf1(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xf1(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	Real l = lambda(z, F1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return -2.*F1_MEAN_K_PERP_SQ/Q*ph_t*(z/l)*G(ph_t_sq, l)*result;
 }
 Real ProkudinSfSet::F_UU_cos_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.5.9a].
 	Real mh = mass(h);
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xh1perpM1(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xh1perpM1(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	Real l = lambda(z, BM_MEAN_K_PERP_SQ, COLLINS_MEAN_P_PERP_SQ);
 	return 4.*M*mh*ph_t_sq*sq(z/l)*G(ph_t_sq, l)*result;
 }
@@ -547,11 +498,8 @@ Real ProkudinSfSet::F_UL_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Rea
 	Real mh = mass(h);
 	Real Q = std::sqrt(Q_sq);
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
 	// Use WW-type approximation to rewrite in terms of `xh1LperpM1`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xh1LperpM1(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xh1LperpM1(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	// Approximate width with `H1_MEAN_K_PERP_SQ`.
 	Real l = lambda(z, H1_MEAN_K_PERP_SQ, COLLINS_MEAN_P_PERP_SQ);
 	return -8.*M*mh*z*ph_t/(Q*l)*G(ph_t_sq, l)*result;
@@ -559,10 +507,7 @@ Real ProkudinSfSet::F_UL_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Rea
 Real ProkudinSfSet::F_UL_sin_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.6.2a].
 	Real mh = mass(h);
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xh1LperpM1(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xh1LperpM1(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	// Approximate width with `H1_MEAN_K_PERP_SQ`.
 	Real l = lambda(z, H1_MEAN_K_PERP_SQ, COLLINS_MEAN_P_PERP_SQ);
 	return 4.*M*mh*ph_t_sq*sq(z/l)*G(ph_t_sq, l)*result;
@@ -571,10 +516,7 @@ Real ProkudinSfSet::F_UL_sin_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Re
 Real ProkudinSfSet::F_UTT_sin_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.5.7a].
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xf1TperpM1(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xf1TperpM1(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	Real l = lambda(z, SIVERS_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return -2.*M*z*ph_t/l*G(ph_t_sq, l)*result;
 }
@@ -582,16 +524,10 @@ Real ProkudinSfSet::F_UT_sin_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q
 	// Equation [2.7.8a].
 	Real mh = mass(h);
 	Real Q = std::sqrt(Q_sq);
-	Real result_1 = 0.;
 	// Use WW-type approximation to rewrite in terms of `xf1TperpM1`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result_1 += sq(charge(fl))*xf1TperpM1(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
-	Real result_2 = 0.;
+	Real result_1 = (sq_vec(CHARGES)*xf1TperpM1(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	// Use WW-type approximation to rewrite in terms of `h1TperpM2`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result_2 += sq(charge(fl))*xh1TperpM2(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result_2 = (sq_vec(CHARGES)*xh1TperpM2(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	// Approximate width with `SIVERS_MEAN_K_PERP_SQ`.
 	Real l_1 = lambda(z, SIVERS_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	// Approximate width with `PRETZ_MEAN_K_PERP_SQ`.
@@ -607,10 +543,7 @@ Real ProkudinSfSet::F_UT_sin_3phih_m_phis(part::Hadron h, Real x, Real z, Real Q
 	// Equation [2.5.10a].
 	Real mh = mass(h);
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xh1TperpM2(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xh1TperpM2(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	Real l = lambda(z, PRETZ_MEAN_K_PERP_SQ, COLLINS_MEAN_P_PERP_SQ);
 	return 2.*sq(M)*mh*std::pow(z*ph_t/l, 3)*G(ph_t_sq, l)*result;
 }
@@ -618,11 +551,8 @@ Real ProkudinSfSet::F_UT_sin_phis(part::Hadron h, Real x, Real z, Real Q_sq, Rea
 	// Equation [2.7.7a].
 	Real mh = mass(h);
 	Real Q = std::sqrt(Q_sq);
-	Real result = 0.;
 	// WW-type approximation used here (see [2] for details).
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xh1M1(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xh1M1(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	Real l = lambda(z, PRETZ_MEAN_K_PERP_SQ, COLLINS_MEAN_P_PERP_SQ);
 	return 8.*sq(M)*mh*sq(z)/(Q*l)*(1. - ph_t_sq/l)*G(ph_t_sq, l)*result;
 }
@@ -630,20 +560,14 @@ Real ProkudinSfSet::F_UT_sin_phih_p_phis(part::Hadron h, Real x, Real z, Real Q_
 	// Equation [2.5.8a].
 	Real mh = mass(h);
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xh1(fl, x, Q_sq)*H1perpM1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xh1(x, Q_sq)*H1perpM1(h, z, Q_sq)).sum();
 	Real l = lambda(z, H1_MEAN_K_PERP_SQ, COLLINS_MEAN_P_PERP_SQ);
 	return 2.*mh*z*ph_t/l*G(ph_t_sq, l)*result;
 }
 
 Real ProkudinSfSet::F_LL(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.5.5a].
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xg1(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xg1(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	Real l = lambda(z, G1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return G(ph_t_sq, l)*result;
 }
@@ -651,11 +575,8 @@ Real ProkudinSfSet::F_LL_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Rea
 	// Equation [2.7.5a].
 	Real Q = std::sqrt(Q_sq);
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
 	// Uses a WW-type approximation to rewrite in terms of `xg1`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xg1(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xg1(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	// Approximate width with `G1_MEAN_K_PERP_SQ`.
 	Real l = lambda(z, G1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return -2.*G1_MEAN_K_PERP_SQ*z*ph_t/(Q*l)*G(ph_t_sq, l)*result;
@@ -664,11 +585,8 @@ Real ProkudinSfSet::F_LL_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Rea
 Real ProkudinSfSet::F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.6.1a].
 	Real ph_t = std::sqrt(ph_t_sq);
-	Real result = 0.;
 	// Uses a WW-type approximation to rewrite in terms of `xgT`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xgT(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xgT(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	// Approximate width with `G1_MEAN_K_PERP_SQ`.
 	Real l = lambda(z, G1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return 2.*M*x*z*ph_t/l*G(ph_t_sq, l)*result;
@@ -676,11 +594,8 @@ Real ProkudinSfSet::F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_
 Real ProkudinSfSet::F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.7.4a].
 	Real Q = std::sqrt(Q_sq);
-	Real result = 0.;
 	// Uses a WW-type approximation to rewrite in terms of `xgT`.
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xgT(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xgT(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	// Approximate width with `G1_MEAN_K_PERP_SQ`.
 	Real l = lambda(z, G1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return -2.*G1_MEAN_K_PERP_SQ*M*x*ph_t_sq*sq(z/l)/Q*G(ph_t_sq, l)*result;
@@ -688,42 +603,40 @@ Real ProkudinSfSet::F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q
 Real ProkudinSfSet::F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
 	// Equation [2.7.2a].
 	Real Q = std::sqrt(Q_sq);
-	Real result = 0.;
-	for (unsigned fl = 0; fl < NUM_FLAVORS; ++fl) {
-		result += sq(charge(fl))*xgT(fl, x, Q_sq)*D1(h, fl, z, Q_sq);
-	}
+	Real result = (sq_vec(CHARGES)*xgT(x, Q_sq)*D1(h, z, Q_sq)).sum();
 	// Approximate width with `G1_MEAN_K_PERP_SQ`.
 	Real l = lambda(z, G1_MEAN_K_PERP_SQ, D1_MEAN_P_PERP_SQ);
 	return -2.*M*x/Q*G(ph_t_sq, l)*result;
 }
 
 // Fragmentation functions.
-Real ProkudinSfSet::D1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const {
+FlavorVec ProkudinSfSet::D1(part::Hadron h, Real z, Real Q_sq) const {
 	switch (h) {
 	case part::Hadron::PI_P:
-		return _impl->impl.interp_D1_pi_plus[fl]({ z, Q_sq });
+		return eval_interp_arr(_impl->impl.interp_D1_pi_plus, z, Q_sq);
 	case part::Hadron::PI_M:
-		return _impl->impl.interp_D1_pi_minus[fl]({ z, Q_sq });
+		return eval_interp_arr(_impl->impl.interp_D1_pi_minus, z, Q_sq);
 	default:
 		throw HadronOutOfRange(h);
 	}
 }
-Real ProkudinSfSet::H1perpM1(part::Hadron h, unsigned fl, Real z, Real Q_sq) const {
+FlavorVec ProkudinSfSet::H1perpM1(part::Hadron h, Real z, Real Q_sq) const {
 	Real mh = mass(h);
-	Real collins_coeff = 0.;
-	if (h == part::Hadron::PI_P) {
-		if (fl == 0 || fl == 4) {
-			collins_coeff = COLLINS_N_FAV;
-		} else if (fl == 1 || fl == 3) {
-			collins_coeff = COLLINS_N_DISFAV;
-		}
-	} else if (h == part::Hadron::PI_M) {
-		if (fl == 1 || fl == 3) {
-			collins_coeff = COLLINS_N_FAV;
-		} else if (fl == 0 || fl == 4) {
-			collins_coeff = COLLINS_N_DISFAV;
-		}
-	} else {
+	FlavorVec collins_coeff(6, 0.);
+	switch (h) {
+	case part::Hadron::PI_P:
+		collins_coeff = FlavorVec {
+			COLLINS_N_FAV, COLLINS_N_DISFAV, 0.,
+			COLLINS_N_DISFAV, COLLINS_N_FAV, 0.,
+		};
+		break;
+	case part::Hadron::PI_M:
+		collins_coeff = FlavorVec {
+			COLLINS_N_DISFAV, COLLINS_N_FAV, 0.,
+			COLLINS_N_FAV, COLLINS_N_DISFAV, 0.,
+		};
+		break;
+	default:
 		throw HadronOutOfRange(h);
 	}
 	return std::sqrt(E/2.)/(z*mh*COLLINS_M)
@@ -733,90 +646,81 @@ Real ProkudinSfSet::H1perpM1(part::Hadron h, unsigned fl, Real z, Real Q_sq) con
 		*std::pow(COLLINS_GAMMA + COLLINS_DELTA, COLLINS_GAMMA + COLLINS_DELTA)
 		*std::pow(COLLINS_GAMMA, -COLLINS_GAMMA)
 		*std::pow(COLLINS_DELTA, -COLLINS_DELTA)
-		*D1(h, fl, z, Q_sq);
+		*D1(h, z, Q_sq);
 }
 
 // Parton distribution functions.
-Real ProkudinSfSet::xf1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinSfSet::xf1(Real x, Real Q_sq) const {
 	Real Q = std::sqrt(Q_sq);
-	switch (fl) {
-	case 0:
-		return _impl->impl.pdf.parton(8, x, Q) + _impl->impl.pdf.parton(-2, x, Q);
-	case 1:
-		return _impl->impl.pdf.parton(7, x, Q) + _impl->impl.pdf.parton(-1, x, Q);
-	case 2:
-		return _impl->impl.pdf.parton(3, x, Q);
-	case 3:
-		return _impl->impl.pdf.parton(-2, x, Q);
-	case 4:
-		return _impl->impl.pdf.parton(-1, x, Q);
-	case 5:
-		return _impl->impl.pdf.parton(-3, x, Q);
-	default:
-		return 0.;
-	}
+	return FlavorVec {
+		_impl->impl.pdf.parton(8, x, Q) + _impl->impl.pdf.parton(-2, x, Q),
+		_impl->impl.pdf.parton(7, x, Q) + _impl->impl.pdf.parton(-1, x, Q),
+		_impl->impl.pdf.parton(3, x, Q),
+		_impl->impl.pdf.parton(-2, x, Q),
+		_impl->impl.pdf.parton(-1, x, Q),
+		_impl->impl.pdf.parton(-3, x, Q),
+	};
 }
 
 // Transverse momentum distributions.
-Real ProkudinSfSet::xf1TperpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinSfSet::xf1TperpM1(Real x, Real Q_sq) const {
 	// Equation [2.A.4].
 	return -std::sqrt(E/2.)/(M*SIVERS_M_1)
 		*sq(SIVERS_MEAN_K_PERP_SQ)/F1_MEAN_K_PERP_SQ
-		*SIVERS_N[fl]
-		*std::pow(x, SIVERS_ALPHA[fl])*std::pow(1. - x, SIVERS_BETA[fl])
-		*std::pow(SIVERS_ALPHA[fl] + SIVERS_BETA[fl],
-			SIVERS_ALPHA[fl] + SIVERS_BETA[fl])
-		*std::pow(SIVERS_ALPHA[fl], -SIVERS_ALPHA[fl])
-		*std::pow(SIVERS_BETA[fl], -SIVERS_BETA[fl])
-		*xf1(fl, x, Q_sq);
+		*SIVERS_N
+		*pow_vec(x, SIVERS_ALPHA)*pow_vec(1. - x, SIVERS_BETA)
+		*pow_vec(SIVERS_ALPHA + SIVERS_BETA, SIVERS_ALPHA + SIVERS_BETA)
+		*pow_vec(SIVERS_ALPHA, -SIVERS_ALPHA)
+		*pow_vec(SIVERS_BETA, -SIVERS_BETA)
+		*xf1(x, Q_sq);
 }
-Real ProkudinSfSet::xg1(unsigned fl, Real x, Real Q_sq) const {
-	return x*_impl->impl.interp_g1[fl]({ x, Q_sq });
+FlavorVec ProkudinSfSet::xg1(Real x, Real Q_sq) const {
+	return x*eval_interp_arr(_impl->impl.interp_g1, x, Q_sq);
 }
-Real ProkudinSfSet::xgT(unsigned fl, Real x, Real Q_sq) const {
-	return _impl->impl.interp_xgT[fl]({ x, Q_sq });
+FlavorVec ProkudinSfSet::xgT(Real x, Real Q_sq) const {
+	return eval_interp_arr(_impl->impl.interp_xgT, x, Q_sq);
 }
-Real ProkudinSfSet::xh1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinSfSet::xh1(Real x, Real Q_sq) const {
 	// Use the Soffer bound to get an upper limit on transversity (Equation
 	// [2.A.7]).
-	return x*H1_N[fl]
+	return x*H1_N
 		*std::pow(x, H1_ALPHA)*std::pow(1. - x, H1_BETA)
 		*std::pow(H1_ALPHA + H1_BETA, H1_ALPHA + H1_BETA)
 		*std::pow(H1_ALPHA, -H1_ALPHA)
 		*std::pow(H1_BETA, -H1_BETA)
-		*_impl->impl.interp_sb[fl]({ x, Q_sq });
+		*eval_interp_arr(_impl->impl.interp_sb, x, Q_sq);
 }
-Real ProkudinSfSet::xh1M1(unsigned fl, Real x, Real Q_sq) const {
-	return H1_MEAN_K_PERP_SQ/(2.*sq(M))*xh1(fl, x, Q_sq);
+FlavorVec ProkudinSfSet::xh1M1(Real x, Real Q_sq) const {
+	return H1_MEAN_K_PERP_SQ/(2.*sq(M))*xh1(x, Q_sq);
 }
-Real ProkudinSfSet::xh1LperpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinSfSet::xh1LperpM1(Real x, Real Q_sq) const {
 	// Data only exists for up and down quarks.
-	if (!(fl == 0 || fl == 1)) {
-		return 0.;
-	} else {
-		return _impl->impl.interp_xh1LperpM1[fl]({ x, Q_sq });
-	}
+	return FlavorVec {
+		_impl->impl.interp_xh1LperpM1[0]({ x, Q_sq }),
+		_impl->impl.interp_xh1LperpM1[1]({ x, Q_sq }),
+		0., 0., 0., 0.,
+	};
 }
-Real ProkudinSfSet::xh1TperpM2(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinSfSet::xh1TperpM2(Real x, Real Q_sq) const {
 	// Equation [2.A.24].
 	return E/(2.*sq(M)*PRETZ_M_TT_SQ)
 		*std::pow(PRETZ_MEAN_K_PERP_SQ, 3)/F1_MEAN_K_PERP_SQ
-		*PRETZ_N[fl]
+		*PRETZ_N
 		*std::pow(x, PRETZ_ALPHA)*std::pow(1. - x, PRETZ_BETA)
 		*std::pow(PRETZ_ALPHA + PRETZ_BETA, PRETZ_ALPHA + PRETZ_BETA)
 		*std::pow(PRETZ_ALPHA, -PRETZ_ALPHA)
 		*std::pow(PRETZ_BETA, -PRETZ_BETA)
-		*(xf1(fl, x, Q_sq) - xg1(fl, x, Q_sq));
+		*(xf1(x, Q_sq) - xg1(x, Q_sq));
 }
-Real ProkudinSfSet::xh1perpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec ProkudinSfSet::xh1perpM1(Real x, Real Q_sq) const {
 	// Equation [2.A.18].
 	return -std::sqrt(E/2.)/(M*BM_M_1)
 		*sq(BM_MEAN_K_PERP_SQ)/F1_MEAN_K_PERP_SQ
-		*BM_LAMBDA[fl] * BM_A[fl]
-		*std::pow(x, BM_ALPHA[fl])*std::pow(1. - x, BM_BETA)
-		*std::pow(BM_ALPHA[fl] + BM_BETA, BM_ALPHA[fl] + BM_BETA)
-		*std::pow(BM_ALPHA[fl], -BM_ALPHA[fl])
-		*std::pow(BM_BETA, -BM_BETA)
-		*xf1(fl, x, Q_sq);
+		*BM_LAMBDA * BM_A
+		*pow_vec(x, BM_ALPHA)*pow_vec(1. - x, BM_BETA)
+		*pow_vec(BM_ALPHA + BM_BETA, BM_ALPHA + BM_BETA)
+		*pow_vec(BM_ALPHA, -BM_ALPHA)
+		*pow_vec(BM_BETA, -BM_BETA)
+		*xf1(x, Q_sq);
 }
 

--- a/src/sf_set/prokudin.cpp
+++ b/src/sf_set/prokudin.cpp
@@ -123,22 +123,22 @@ Real lambda(Real z, Real mean_kperp_sq, Real mean_pperp_sq) {
 // Struct summarizing the TMD Gaussian variances.
 GaussianWwTmdVars const TMD_VARS = []() {
 	GaussianWwTmdVars vars{};
-	vars.f1 = F1_MEAN_K_PERP_SQ;
-	vars.f1Tperp = SIVERS_MEAN_K_PERP_SQ;
+	vars.f1 = FlavorVec(F1_MEAN_K_PERP_SQ);
+	vars.f1Tperp = FlavorVec(SIVERS_MEAN_K_PERP_SQ);
 	// vars.fT
-	vars.g1 = G1_MEAN_K_PERP_SQ;
-	vars.g1Tperp = G1_MEAN_K_PERP_SQ;
-	vars.gT = G1_MEAN_K_PERP_SQ;
-	vars.h1 = H1_MEAN_K_PERP_SQ;
-	vars.h1perp = BM_MEAN_K_PERP_SQ;
-	vars.h1Lperp = H1_MEAN_K_PERP_SQ;
-	vars.h1Tperp = PRETZ_MEAN_K_PERP_SQ;
+	vars.g1 = FlavorVec(G1_MEAN_K_PERP_SQ);
+	vars.g1Tperp = FlavorVec(G1_MEAN_K_PERP_SQ);
+	vars.gT = FlavorVec(G1_MEAN_K_PERP_SQ);
+	vars.h1 = FlavorVec(H1_MEAN_K_PERP_SQ);
+	vars.h1perp = FlavorVec(BM_MEAN_K_PERP_SQ);
+	vars.h1Lperp = FlavorVec(H1_MEAN_K_PERP_SQ);
+	vars.h1Tperp = FlavorVec(PRETZ_MEAN_K_PERP_SQ);
 	// vars.h
-	vars.hL = H1_MEAN_K_PERP_SQ;
-	vars.hT = HT_MEAN_K_PERP_SQ;
-	vars.hTperp = HT_MEAN_K_PERP_SQ;
-	vars.D1 = D1_MEAN_P_PERP_SQ;
-	vars.H1perp = COLLINS_MEAN_P_PERP_SQ;
+	vars.hL = FlavorVec(H1_MEAN_K_PERP_SQ);
+	vars.hT = FlavorVec(HT_MEAN_K_PERP_SQ);
+	vars.hTperp = FlavorVec(HT_MEAN_K_PERP_SQ);
+	vars.D1 = FlavorVec(D1_MEAN_P_PERP_SQ);
+	vars.H1perp = FlavorVec(COLLINS_MEAN_P_PERP_SQ);
 	// `fT` and `h` are neglected because of a lack of information about the
 	// `fT` TMD (see the discussion in section 7.6 of [2]).
 	return vars;

--- a/src/structure_function.cpp
+++ b/src/structure_function.cpp
@@ -751,3 +751,564 @@ Real GaussianWwTmdSfSet::F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq
 	return M_F_LT_COS_PHIS_WW(GAUSSIAN);
 }
 
+// Provide overrides to compute groups of Gaussian structure functions more
+// efficiently. This makes use of caching to avoid computing TMDs more times
+// than necessary.
+SfBaseUU GaussianTmdSfSet::sf_base_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	// For example, f1 is used by all three structure functions, but we compute
+	// it only once here and re-use the cached value three times instead.
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(h1perp); CACHE_TMD(h);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(H_tilde);
+	return {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+}
+SfBaseUL GaussianTmdSfSet::sf_base_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(fLperp); CACHE_TMD(g1); CACHE_TMD(h1Lperp); CACHE_TMD(hL);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde);
+	return {
+		M_F_UL_SIN_PHIH(GAUSSIAN),
+		M_F_UL_SIN_2PHIH(GAUSSIAN),
+	};
+}
+SfBaseUT GaussianTmdSfSet::sf_base_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1Tperp); CACHE_TMD(fT); CACHE_TMD(fTperp); CACHE_TMD(g1Tperp); CACHE_TMD(h1); CACHE_TMD(h1Tperp); CACHE_TMD(hT); CACHE_TMD(hTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde);
+	return {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN),
+	};
+}
+SfBaseUP GaussianTmdSfSet::sf_base_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1Tperp); CACHE_TMD(fT); CACHE_TMD(fLperp); CACHE_TMD(fTperp); CACHE_TMD(g1); CACHE_TMD(g1Tperp); CACHE_TMD(h1); CACHE_TMD(h1Lperp); CACHE_TMD(h1Tperp); CACHE_TMD(hL); CACHE_TMD(hT); CACHE_TMD(hTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde);
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH(GAUSSIAN),
+		M_F_UL_SIN_2PHIH(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN),
+	};
+	return { ul, ut };
+}
+SfBaseLU GaussianTmdSfSet::sf_base_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(gperp); CACHE_TMD(h1perp); CACHE_TMD(e);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Gperp_tilde); CACHE_FF(E_tilde);
+	return {
+		M_F_LU_SIN_PHIH(GAUSSIAN),
+	};
+}
+SfBaseLL GaussianTmdSfSet::sf_base_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(g1); CACHE_TMD(gLperp); CACHE_TMD(h1Lperp); CACHE_TMD(eL);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(E_tilde);
+	return {
+		M_F_LL(GAUSSIAN),
+		M_F_LL_COS_PHIH(GAUSSIAN),
+	};
+}
+SfBaseLT GaussianTmdSfSet::sf_base_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1Tperp); CACHE_TMD(g1Tperp); CACHE_TMD(gT); CACHE_TMD(gTperp); CACHE_TMD(h1); CACHE_TMD(h1Tperp); CACHE_TMD(eT); CACHE_TMD(eTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(E_tilde);
+	return {
+		M_F_LT_COS_PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_PHIS(GAUSSIAN),
+	};
+}
+SfBaseLP GaussianTmdSfSet::sf_base_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1Tperp); CACHE_TMD(g1); CACHE_TMD(gLperp); CACHE_TMD(g1Tperp); CACHE_TMD(gT); CACHE_TMD(gTperp); CACHE_TMD(h1); CACHE_TMD(h1Lperp); CACHE_TMD(h1Tperp); CACHE_TMD(eL); CACHE_TMD(eT); CACHE_TMD(eTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(E_tilde);
+	SfBaseLL ll = {
+		M_F_LL(GAUSSIAN),
+		M_F_LL_COS_PHIH(GAUSSIAN),
+	};
+	SfBaseLT lt = {
+		M_F_LT_COS_PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_PHIS(GAUSSIAN),
+	};
+	return { ll, lt };
+}
+
+SfUU GaussianTmdSfSet::sf_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	return {
+		sf_base_uu(h, x, z, Q_sq, ph_t_sq),
+	};
+}
+SfUL GaussianTmdSfSet::sf_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(fLperp); CACHE_TMD(g1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp); CACHE_TMD(h); CACHE_TMD(hL);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH(GAUSSIAN),
+		M_F_UL_SIN_2PHIH(GAUSSIAN),
+	};
+	return { uu, ul };
+}
+SfUT GaussianTmdSfSet::sf_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(f1Tperp); CACHE_TMD(fT); CACHE_TMD(fTperp); CACHE_TMD(g1Tperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Tperp); CACHE_TMD(h); CACHE_TMD(hT); CACHE_TMD(hTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN),
+	};
+	return { uu, ut };
+}
+SfUP GaussianTmdSfSet::sf_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(f1Tperp); CACHE_TMD(fT); CACHE_TMD(fLperp); CACHE_TMD(fTperp); CACHE_TMD(g1); CACHE_TMD(g1Tperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp); CACHE_TMD(h1Tperp); CACHE_TMD(h); CACHE_TMD(hL); CACHE_TMD(hT); CACHE_TMD(hTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH(GAUSSIAN),
+		M_F_UL_SIN_2PHIH(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN),
+	};
+	return { uu, ul, ut };
+}
+SfLU GaussianTmdSfSet::sf_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(gperp); CACHE_TMD(h1perp); CACHE_TMD(h); CACHE_TMD(e);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde); CACHE_FF(E_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH(GAUSSIAN),
+	};
+	return { uu, lu };
+}
+SfLL GaussianTmdSfSet::sf_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(fLperp); CACHE_TMD(g1); CACHE_TMD(gperp); CACHE_TMD(gLperp); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp); CACHE_TMD(h); CACHE_TMD(hL); CACHE_TMD(e); CACHE_TMD(eL);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde); CACHE_FF(E_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH(GAUSSIAN),
+		M_F_UL_SIN_2PHIH(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH(GAUSSIAN),
+	};
+	SfBaseLL ll = {
+		M_F_LL(GAUSSIAN),
+		M_F_LL_COS_PHIH(GAUSSIAN),
+	};
+	return { uu, ul, lu, ll };
+}
+SfLT GaussianTmdSfSet::sf_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(f1Tperp); CACHE_TMD(fT); CACHE_TMD(fTperp); CACHE_TMD(g1Tperp); CACHE_TMD(gT); CACHE_TMD(gTperp); CACHE_TMD(gperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Tperp); CACHE_TMD(h); CACHE_TMD(hT); CACHE_TMD(hTperp); CACHE_TMD(e); CACHE_TMD(eT); CACHE_TMD(eTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde); CACHE_FF(E_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN),
+	};
+	SfBaseLT lt = {
+		M_F_LT_COS_PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_PHIS(GAUSSIAN),
+	};
+	return { uu, ut, lu, lt };
+}
+SfLP GaussianTmdSfSet::sf_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(fperp); CACHE_TMD(f1Tperp); CACHE_TMD(fT); CACHE_TMD(fLperp); CACHE_TMD(fTperp); CACHE_TMD(g1); CACHE_TMD(g1Tperp); CACHE_TMD(gT); CACHE_TMD(gperp); CACHE_TMD(gLperp); CACHE_TMD(gTperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp); CACHE_TMD(h1Tperp); CACHE_TMD(h); CACHE_TMD(hL); CACHE_TMD(hT); CACHE_TMD(hTperp); CACHE_TMD(e); CACHE_TMD(eL); CACHE_TMD(eT); CACHE_TMD(eTperp);
+	CACHE_FF(D1); CACHE_FF(H1perp); CACHE_FF(Dperp_tilde); CACHE_FF(Gperp_tilde); CACHE_FF(H_tilde); CACHE_FF(E_tilde);
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT(GAUSSIAN),
+		M_F_UU_COS_PHIH(GAUSSIAN),
+		M_F_UU_COS_2PHIH(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH(GAUSSIAN),
+		M_F_UL_SIN_2PHIH(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIS(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN),
+	};
+	SfBaseLT lt = {
+		M_F_LT_COS_PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS(GAUSSIAN),
+		M_F_LT_COS_PHIS(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH(GAUSSIAN),
+	};
+	SfBaseLL ll = {
+		M_F_LL(GAUSSIAN),
+		M_F_LL_COS_PHIH(GAUSSIAN),
+	};
+	return { uu, ul, ut, lu, ll, lt };
+}
+
+// Provide more efficient overrides for WW-type approximated Gaussian TmdSets.
+SfBaseUU GaussianWwTmdSfSet::sf_base_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(h1perp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	return {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+}
+SfBaseUL GaussianWwTmdSfSet::sf_base_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(h1Lperp);
+	CACHE_FF(H1perp);
+	FlavorVec xhL = -2.*TMD_X_MOM1(h1Lperp)/x;
+	return {
+		M_F_UL_SIN_PHIH_WW(GAUSSIAN),
+		M_F_UL_SIN_2PHIH_WW(GAUSSIAN),
+	};
+}
+SfBaseUT GaussianWwTmdSfSet::sf_base_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1Tperp); CACHE_TMD(h1); CACHE_TMD(h1Tperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfT = -TMD_X_MOM1(f1Tperp)/x;
+	FlavorVec xfTperp = xf1Tperp/x;
+	FlavorVec xhT = -(xh1 + TMD_X_MOM1(h1Tperp))/x;
+	FlavorVec xhTperp = (xh1 - TMD_X_MOM1(h1Tperp))/x;
+	return {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN),
+	};
+}
+SfBaseUP GaussianWwTmdSfSet::sf_base_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1Tperp); CACHE_TMD(h1); CACHE_TMD(h1Tperp); CACHE_TMD(h1Lperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfT = -TMD_X_MOM1(f1Tperp)/x;
+	FlavorVec xfTperp = xf1Tperp/x;
+	FlavorVec xhL = -2.*TMD_X_MOM1(h1Lperp)/x;
+	FlavorVec xhT = -(xh1 + TMD_X_MOM1(h1Tperp))/x;
+	FlavorVec xhTperp = (xh1 - TMD_X_MOM1(h1Tperp))/x;
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH_WW(GAUSSIAN),
+		M_F_UL_SIN_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN),
+	};
+	return { ul, ut };
+}
+SfBaseLU GaussianWwTmdSfSet::sf_base_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	static_cast<void>(h);
+	static_cast<void>(x);
+	static_cast<void>(z);
+	static_cast<void>(Q_sq);
+	static_cast<void>(ph_t_sq);
+	return {
+		M_F_LU_SIN_PHIH_WW(GAUSSIAN),
+	};
+}
+SfBaseLL GaussianWwTmdSfSet::sf_base_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(g1);
+	CACHE_FF(D1);
+	FlavorVec xgLperp = xg1/x;
+	return {
+		M_F_LL_WW(GAUSSIAN),
+		M_F_LL_COS_PHIH_WW(GAUSSIAN),
+	};
+}
+SfBaseLT GaussianWwTmdSfSet::sf_base_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(g1Tperp);
+	CACHE_FF(D1);
+	FlavorVec xgT = TMD_X_MOM1(g1Tperp)/x;
+	FlavorVec xgTperp = xg1Tperp/x;
+	return {
+		M_F_LT_COS_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_PHIS_WW(GAUSSIAN),
+	};
+}
+SfBaseLP GaussianWwTmdSfSet::sf_base_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(g1); CACHE_TMD(g1Tperp);
+	CACHE_FF(D1);
+	FlavorVec xgT = TMD_X_MOM1(g1Tperp)/x;
+	FlavorVec xgLperp = xg1/x;
+	FlavorVec xgTperp = xg1Tperp/x;
+	SfBaseLL ll = {
+		M_F_LL_WW(GAUSSIAN),
+		M_F_LL_COS_PHIH_WW(GAUSSIAN),
+	};
+	SfBaseLT lt = {
+		M_F_LT_COS_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_PHIS_WW(GAUSSIAN),
+	};
+	return { ll, lt };
+}
+
+SfUU GaussianWwTmdSfSet::sf_uu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	return {
+		sf_base_uu(h, x, z, Q_sq, ph_t_sq),
+	};
+}
+SfUL GaussianWwTmdSfSet::sf_ul(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	FlavorVec xhL = -2.*TMD_X_MOM1(h1Lperp)/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH_WW(GAUSSIAN),
+		M_F_UL_SIN_2PHIH_WW(GAUSSIAN),
+	};
+	return { uu, ul };
+}
+SfUT GaussianWwTmdSfSet::sf_ut(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(f1Tperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Tperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfT = -TMD_X_MOM1(f1Tperp)/x;
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xfTperp = xf1Tperp/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	FlavorVec xhT = -(xh1 + TMD_X_MOM1(h1Tperp))/x;
+	FlavorVec xhTperp = (xh1 - TMD_X_MOM1(h1Tperp))/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN),
+	};
+	return { uu, ut };
+}
+SfUP GaussianWwTmdSfSet::sf_up(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(f1Tperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp); CACHE_TMD(h1Tperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfT = -TMD_X_MOM1(f1Tperp)/x;
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xfTperp = xf1Tperp/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	FlavorVec xhL = -2.*TMD_X_MOM1(h1Lperp)/x;
+	FlavorVec xhT = -(xh1 + TMD_X_MOM1(h1Tperp))/x;
+	FlavorVec xhTperp = (xh1 - TMD_X_MOM1(h1Tperp))/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH_WW(GAUSSIAN),
+		M_F_UL_SIN_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN),
+	};
+	return { uu, ul, ut };
+}
+SfLU GaussianWwTmdSfSet::sf_lu(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(h1perp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH_WW(GAUSSIAN),
+	};
+	return { uu, lu };
+}
+SfLL GaussianWwTmdSfSet::sf_ll(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(g1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xgLperp = xg1/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	FlavorVec xhL = -2.*TMD_X_MOM1(h1Lperp)/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH_WW(GAUSSIAN),
+		M_F_UL_SIN_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH_WW(GAUSSIAN),
+	};
+	SfBaseLL ll = {
+		M_F_LL_WW(GAUSSIAN),
+		M_F_LL_COS_PHIH_WW(GAUSSIAN),
+	};
+	return { uu, ul, lu, ll };
+}
+SfLT GaussianWwTmdSfSet::sf_lt(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(f1Tperp); CACHE_TMD(g1Tperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Tperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfT = -TMD_X_MOM1(f1Tperp)/x;
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xfTperp = xf1Tperp/x;
+	FlavorVec xgT = TMD_X_MOM1(g1Tperp)/x;
+	FlavorVec xgTperp = xg1Tperp/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	FlavorVec xhT = -(xh1 + TMD_X_MOM1(h1Tperp))/x;
+	FlavorVec xhTperp = (xh1 - TMD_X_MOM1(h1Tperp))/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN),
+	};
+	SfBaseLT lt = {
+		M_F_LT_COS_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_PHIS_WW(GAUSSIAN),
+	};
+	return { uu, ut, lu, lt };
+}
+SfLP GaussianWwTmdSfSet::sf_lp(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
+	CACHE_TMD(f1); CACHE_TMD(f1Tperp); CACHE_TMD(g1); CACHE_TMD(g1Tperp); CACHE_TMD(h1); CACHE_TMD(h1perp); CACHE_TMD(h1Lperp); CACHE_TMD(h1Tperp);
+	CACHE_FF(D1); CACHE_FF(H1perp);
+	FlavorVec xfT = -TMD_X_MOM1(f1Tperp)/x;
+	FlavorVec xfperp = xf1/x;
+	FlavorVec xfTperp = xf1Tperp/x;
+	FlavorVec xgT = TMD_X_MOM1(g1Tperp)/x;
+	FlavorVec xgLperp = xg1/x;
+	FlavorVec xgTperp = xg1Tperp/x;
+	FlavorVec xh = -2.*TMD_X_MOM1(h1perp)/x;
+	FlavorVec xhL = -2.*TMD_X_MOM1(h1Lperp)/x;
+	FlavorVec xhT = -(xh1 + TMD_X_MOM1(h1Tperp))/x;
+	FlavorVec xhTperp = (xh1 - TMD_X_MOM1(h1Tperp))/x;
+	SfBaseUU uu = {
+		0.,
+		M_F_UUT_WW(GAUSSIAN),
+		M_F_UU_COS_PHIH_WW(GAUSSIAN),
+		M_F_UU_COS_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUL ul = {
+		M_F_UL_SIN_PHIH_WW(GAUSSIAN),
+		M_F_UL_SIN_2PHIH_WW(GAUSSIAN),
+	};
+	SfBaseUT ut = {
+		0.,
+		M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIS_WW(GAUSSIAN),
+		M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN),
+	};
+	SfBaseLT lt = {
+		M_F_LT_COS_PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_2PHIH_M_PHIS_WW(GAUSSIAN),
+		M_F_LT_COS_PHIS_WW(GAUSSIAN),
+	};
+	SfBaseLU lu = {
+		M_F_LU_SIN_PHIH_WW(GAUSSIAN),
+	};
+	SfBaseLL ll = {
+		M_F_LL_WW(GAUSSIAN),
+		M_F_LL_COS_PHIH_WW(GAUSSIAN),
+	};
+	return { uu, ul, ut, lu, ll, lt };
+}
+

--- a/src/structure_function.cpp
+++ b/src/structure_function.cpp
@@ -10,18 +10,18 @@
 // These macros are used to make it a little easier to read the structure
 // function definitions below. They compute the convolution integrals of the
 // form `C[omega f D]`.
-#define CONVOLVE(weight_type, tmd, ff) \
-	convolve( \
+#define CONVOLVE_NUMERIC(weight_type, tmd, ff) \
+	convolve_numeric( \
 		tmd_set, \
 		Weight::weight_type, \
 		&TmdSet::x ## tmd, &TmdSet::ff, \
 		target, h, x, z, Q_sq, ph_t_sq)
-#define CONVOLVE_TILDE(weight_type, tmd, ff, tmd_tilde, ff_tilde, sign) \
+#define CONVOLVE_TILDE_NUMERIC(weight_type, tmd, ff, tmd_tilde, ff_tilde, sign) \
 	( \
 		(2.*mass(target)*x)/std::sqrt(Q_sq) \
-			*CONVOLVE(weight_type, tmd, ff) \
+			*CONVOLVE_NUMERIC(weight_type, tmd, ff) \
 		+ (sign)*(2.*mass(h))/(z*std::sqrt(Q_sq)) \
-			*CONVOLVE(weight_type, tmd_tilde, ff_tilde))
+			*CONVOLVE_NUMERIC(weight_type, tmd_tilde, ff_tilde))
 
 #define CONVOLVE_GAUSSIAN(weight_type, tmd, ff) \
 	convolve_gaussian( \
@@ -30,12 +30,89 @@
 		tmd_set.mean_ ## tmd.data(), &GaussianTmdSet::x ## tmd, \
 		tmd_set.mean_ ## ff.data(), &GaussianTmdSet::ff, \
 		target, h, x, z, Q_sq, ph_t_sq)
-#define CONVOLVE_GAUSSIAN_TILDE(weight_type, tmd, ff, tmd_tilde, ff_tilde, sign) \
+#define CONVOLVE_TILDE_GAUSSIAN(weight_type, tmd, ff, tmd_tilde, ff_tilde, sign) \
 	( \
 		(2.*mass(target)*x)/std::sqrt(Q_sq) \
 			*CONVOLVE_GAUSSIAN(weight_type, tmd, ff) \
 		+ (sign)*(2.*mass(h))/(z*std::sqrt(Q_sq)) \
 			*CONVOLVE_GAUSSIAN(weight_type, tmd_tilde, ff_tilde))
+
+#define CONVOLVE(METHOD, weight_type, tmd, ff) \
+	(CONVOLVE_##METHOD(weight_type, tmd, ff))
+#define CONVOLVE_TILDE(METHOD, weight_type, tmd, ff, tmd_tilde, ff_tilde, sign) \
+	(CONVOLVE_TILDE_##METHOD(weight_type, tmd, ff, tmd_tilde, ff_tilde, sign))
+
+// Definitions of structure functions in terms of convolutions on TMDs and FFs.
+#define M_F_UUT(METHOD) (CONVOLVE(METHOD, W0, f1, D1))
+#define M_F_UU_COS_PHIH(METHOD) ( \
+	CONVOLVE_TILDE(METHOD, WA1, h, H1perp, f1, Dperp_tilde, +1) \
+	- CONVOLVE_TILDE(METHOD, WB1, fperp, D1, h1perp, H_tilde, +1))
+#define M_F_UU_COS_2PHIH(METHOD) (CONVOLVE(METHOD, WAB2, h1perp, H1perp))
+#define M_F_UL_SIN_PHIH(METHOD) ( \
+	CONVOLVE_TILDE(METHOD, WA1, hL, H1perp, g1, Gperp_tilde, +1) \
+	+ CONVOLVE_TILDE(METHOD, WB1, fLperp, D1, h1Lperp, H_tilde, -1))
+#define M_F_UL_SIN_2PHIH(METHOD) (CONVOLVE(METHOD, WAB2, h1Lperp, H1perp))
+#define M_F_UTT_SIN_PHIH_M_PHIS(METHOD) (-CONVOLVE(METHOD, WB1, f1Tperp, D1))
+// This follows equation [2.7.8a], but we choose not to simplify using WW- type
+// approximations because the simplification would involve TMDs "before"
+// integration, where we have chosen to apply WW-type approximations only
+// "after" integration. This means that the following convolution may be less
+// efficient than it could be otherwise.
+#define M_F_UT_SIN_2PHIH_M_PHIS(METHOD) ( \
+	0.5*CONVOLVE_TILDE(METHOD, WAB2, hT, H1perp, g1Tperp, Gperp_tilde, +1) \
+	+ 0.5*CONVOLVE_TILDE(METHOD, WAB2, hTperp, H1perp, f1Tperp, Dperp_tilde, -1) \
+	+ CONVOLVE_TILDE(METHOD, WC2, fTperp, D1, h1Tperp, H_tilde, -1))
+#define M_F_UT_SIN_3PHIH_M_PHIS(METHOD) (CONVOLVE(METHOD, W3, h1Tperp, H1perp))
+#define M_F_UT_SIN_PHIS(METHOD) ( \
+	CONVOLVE_TILDE(METHOD, W0, fT, D1, h1, H_tilde, -1) \
+	- 0.5*CONVOLVE_TILDE(METHOD, WB2, hT, H1perp, g1Tperp, Gperp_tilde, +1) \
+	+ 0.5*CONVOLVE_TILDE(METHOD, WB2, hTperp, H1perp, f1Tperp, Dperp_tilde, -1))
+#define M_F_UT_SIN_PHIH_P_PHIS(METHOD) (CONVOLVE(METHOD, WA1, h1, H1perp))
+#define M_F_LU_SIN_PHIH(METHOD) ( \
+	CONVOLVE_TILDE(METHOD, WA1, e, H1perp, f1, Gperp_tilde, +1) \
+	+ CONVOLVE_TILDE(METHOD, WB1, gperp, D1, h1perp, E_tilde, +1))
+#define M_F_LL(METHOD) (CONVOLVE(METHOD, W0, g1, D1))
+#define M_F_LL_COS_PHIH(METHOD) ( \
+	-CONVOLVE_TILDE(METHOD, WA1, eL, H1perp, g1, Dperp_tilde, -1) \
+	- CONVOLVE_TILDE(METHOD, WB1, gLperp, D1, h1Lperp, E_tilde, +1))
+#define M_F_LT_COS_PHIH_M_PHIS(METHOD) (CONVOLVE(METHOD, WB1, g1Tperp, D1))
+#define M_F_LT_COS_2PHIH_M_PHIS(METHOD) ( \
+	-0.5*CONVOLVE_TILDE(METHOD, WAB2, eT, H1perp, g1Tperp, Dperp_tilde, -1) \
+	+ 0.5*CONVOLVE_TILDE(METHOD, WAB2, eTperp, H1perp, f1Tperp, Gperp_tilde, +1) \
+	- CONVOLVE_TILDE(METHOD, WC2, gTperp, D1, h1Tperp, E_tilde, +1))
+#define M_F_LT_COS_PHIS(METHOD) ( \
+	-CONVOLVE_TILDE(METHOD, W0, gT, D1, h1, E_tilde, +1) \
+	+ 0.5*CONVOLVE_TILDE(METHOD, WB2, eT, H1perp, g1Tperp, Dperp_tilde, -1) \
+	+ 0.5*CONVOLVE_TILDE(METHOD, WB2, eTperp, H1perp, f1Tperp, Gperp_tilde, +1))
+
+// WW approximations for the structure functions.
+#define M_F_UUT_WW(METHOD) (CONVOLVE(METHOD, W0, f1, D1))
+#define M_F_UU_COS_PHIH_WW(METHOD) ((2.*mass(target)*x)/std::sqrt(Q_sq)*( \
+	CONVOLVE(METHOD, WA1, h, H1perp) - CONVOLVE(METHOD, WB1, fperp, D1)))
+#define M_F_UU_COS_2PHIH_WW(METHOD) (CONVOLVE(METHOD, WAB2, h1perp, H1perp))
+#define M_F_UL_SIN_PHIH_WW(METHOD) ((2.*mass(target)*x)/std::sqrt(Q_sq)* \
+	CONVOLVE(METHOD, WA1, hL, H1perp))
+#define M_F_UL_SIN_2PHIH_WW(METHOD) (CONVOLVE(METHOD, WAB2, h1Lperp, H1perp))
+#define M_F_UTT_SIN_PHIH_M_PHIS_WW(METHOD) (-CONVOLVE(METHOD, WB1, f1Tperp, D1))
+#define M_F_UT_SIN_2PHIH_M_PHIS_WW(METHOD) ((2.*mass(target)*x)/std::sqrt(Q_sq)*( \
+	0.5*CONVOLVE(METHOD, WAB2, hT, H1perp) \
+	+ 0.5*CONVOLVE(METHOD, WAB2, hTperp, H1perp) \
+	+ CONVOLVE(METHOD, WC2, fTperp, D1)))
+#define M_F_UT_SIN_3PHIH_M_PHIS_WW(METHOD) (CONVOLVE(METHOD, W3, h1Tperp, H1perp))
+#define M_F_UT_SIN_PHIS_WW(METHOD) ((2.*mass(target)*x)/std::sqrt(Q_sq)*( \
+	CONVOLVE(METHOD, W0, fT, D1) \
+	- 0.5*CONVOLVE(METHOD, WB2, hT, H1perp) \
+	+ 0.5*CONVOLVE(METHOD, WB2, hTperp, H1perp)))
+#define M_F_UT_SIN_PHIH_P_PHIS_WW(METHOD) (CONVOLVE(METHOD, WA1, h1, H1perp))
+#define M_F_LU_SIN_PHIH_WW(METHOD) (0.)
+#define M_F_LL_WW(METHOD) (CONVOLVE(METHOD, W0, g1, D1))
+#define M_F_LL_COS_PHIH_WW(METHOD) (-(2.*mass(target)*x)/std::sqrt(Q_sq)* \
+	CONVOLVE(METHOD, WB1, gLperp, D1))
+#define M_F_LT_COS_PHIH_M_PHIS_WW(METHOD) (CONVOLVE(METHOD, WB1, g1Tperp, D1))
+#define M_F_LT_COS_2PHIH_M_PHIS_WW(METHOD) (-(2.*mass(target)*x)/std::sqrt(Q_sq)* \
+	CONVOLVE(METHOD, WC2, gTperp, D1))
+#define M_F_LT_COS_PHIS_WW(METHOD) (-(2.*mass(target)*x)/std::sqrt(Q_sq)* \
+	CONVOLVE(METHOD, W0, gT, D1))
 
 using namespace sidis;
 using namespace sidis::math;
@@ -45,8 +122,8 @@ namespace {
 
 using Tmd = Real (TmdSet::*)(unsigned, Real, Real, Real) const;
 using Ff = Real (TmdSet::*)(part::Hadron, unsigned, Real, Real, Real) const;
-using TmdGaussian = Real (GaussianTmdSet::*)(unsigned, Real, Real) const;
-using FfGaussian = Real (GaussianTmdSet::*)(part::Hadron, unsigned, Real, Real) const;
+using GaussianTmd = Real (GaussianTmdSet::*)(unsigned, Real, Real) const;
+using GaussianFf = Real (GaussianTmdSet::*)(part::Hadron, unsigned, Real, Real) const;
 
 enum class Weight {
 	W0,
@@ -59,7 +136,7 @@ enum class Weight {
 	W3,
 };
 
-Real convolve(
+Real convolve_numeric(
 		TmdSet const& tmd_set,
 		Weight weight_type,
 		Tmd tmd, Ff ff,
@@ -129,8 +206,8 @@ Real convolve(
 Real convolve_gaussian(
 		GaussianTmdSet const& tmd_set,
 		Weight weight_type,
-		Real const* mean_tmd, TmdGaussian tmd,
-		Real const* mean_ff, FfGaussian ff,
+		Real const* mean_tmd, GaussianTmd tmd,
+		Real const* mean_ff, GaussianFf ff,
 		part::Nucleus target, part::Hadron h,
 		Real x, Real z, Real Q_sq, Real ph_t_sq) {
 	Real M = mass(target);
@@ -364,72 +441,60 @@ Real TmdSfSet::F_UUL(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real TmdSfSet::F_UUT(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(W0, f1, D1);
+	return M_F_UUT(NUMERIC);
 }
 Real TmdSfSet::F_UU_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_TILDE(WA1, h, H1perp, f1, Dperp_tilde, +1)
-		- CONVOLVE_TILDE(WB1, fperp, D1, h1perp, H_tilde, +1);
+	return M_F_UU_COS_PHIH(NUMERIC);
 }
 Real TmdSfSet::F_UU_cos_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WAB2, h1perp, H1perp);
+	return M_F_UU_COS_2PHIH(NUMERIC);
 }
 
 Real TmdSfSet::F_UL_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_TILDE(WA1, hL, H1perp, g1, Gperp_tilde, +1)
-		+ CONVOLVE_TILDE(WB1, fLperp, D1, h1Lperp, H_tilde, -1);
+	return M_F_UL_SIN_PHIH(NUMERIC);
 }
 Real TmdSfSet::F_UL_sin_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WAB2, h1Lperp, H1perp);
+	return M_F_UL_SIN_2PHIH(NUMERIC);
 }
 
 Real TmdSfSet::F_UTL_sin_phih_m_phis(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real TmdSfSet::F_UTT_sin_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE(WB1, f1Tperp, D1);
+	return M_F_UTT_SIN_PHIH_M_PHIS(NUMERIC);
 }
 Real TmdSfSet::F_UT_sin_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return 0.5*CONVOLVE_TILDE(WAB2, hT, H1perp, g1Tperp, Gperp_tilde, +1)
-		+ 0.5*CONVOLVE_TILDE(WAB2, hTperp, H1perp, f1Tperp, Dperp_tilde, -1)
-		+ CONVOLVE_TILDE(WC2, fTperp, D1, h1Tperp, H_tilde, -1);
+	return M_F_UT_SIN_2PHIH_M_PHIS(NUMERIC);
 }
 Real TmdSfSet::F_UT_sin_3phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(W3, h1Tperp, H1perp);
+	return M_F_UT_SIN_3PHIH_M_PHIS(NUMERIC);
 }
 Real TmdSfSet::F_UT_sin_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_TILDE(W0, fT, D1, h1, H_tilde, -1)
-		- 0.5*CONVOLVE_TILDE(WB2, hT, H1perp, g1Tperp, Gperp_tilde, +1)
-		+ 0.5*CONVOLVE_TILDE(WB2, hTperp, H1perp, f1Tperp, Dperp_tilde, -1);
+	return M_F_UT_SIN_PHIS(NUMERIC);
 }
 Real TmdSfSet::F_UT_sin_phih_p_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WA1, h1, H1perp);
+	return M_F_UT_SIN_PHIH_P_PHIS(NUMERIC);
 }
 
 Real TmdSfSet::F_LU_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_TILDE(WA1, e, H1perp, f1, Gperp_tilde, +1)
-		+ CONVOLVE_TILDE(WB1, gperp, D1, h1perp, E_tilde, +1);
+	return M_F_LU_SIN_PHIH(NUMERIC);
 }
 
 Real TmdSfSet::F_LL(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(W0, g1, D1);
+	return M_F_LL(NUMERIC);
 }
 Real TmdSfSet::F_LL_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE_TILDE(WA1, eL, H1perp, g1, Dperp_tilde, -1)
-		- CONVOLVE_TILDE(WB1, gLperp, D1, h1Lperp, E_tilde, +1);
+	return M_F_LL_COS_PHIH(NUMERIC);
 }
 
 Real TmdSfSet::F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WB1, g1Tperp, D1);
+	return M_F_LT_COS_PHIH_M_PHIS(NUMERIC);
 }
 Real TmdSfSet::F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -0.5*CONVOLVE_TILDE(WAB2, eT, H1perp, g1Tperp, Dperp_tilde, -1)
-		+ 0.5*CONVOLVE_TILDE(WAB2, eTperp, H1perp, f1Tperp, Gperp_tilde, +1)
-		- CONVOLVE_TILDE(WC2, gTperp, D1, h1Tperp, E_tilde, +1);
+	return M_F_LT_COS_2PHIH_M_PHIS(NUMERIC);
 }
 Real TmdSfSet::F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE_TILDE(W0, gT, D1, h1, E_tilde, +1)
-		+ 0.5*CONVOLVE_TILDE(WB2, eT, H1perp, g1Tperp, Dperp_tilde, -1)
-		+ 0.5*CONVOLVE_TILDE(WB2, eTperp, H1perp, f1Tperp, Gperp_tilde, +1);
+	return M_F_LT_COS_PHIS(NUMERIC);
 }
 
 // Gaussian approximation.
@@ -437,72 +502,60 @@ Real GaussianTmdSfSet::F_UUL(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real GaussianTmdSfSet::F_UUT(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(W0, f1, D1);
+	return M_F_UUT(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UU_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN_TILDE(WA1, h, H1perp, f1, Dperp_tilde, +1)
-		- CONVOLVE_GAUSSIAN_TILDE(WB1, fperp, D1, h1perp, H_tilde, +1);
+	return M_F_UU_COS_PHIH(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UU_cos_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WAB2, h1perp, H1perp);
+	return M_F_UU_COS_2PHIH(GAUSSIAN);
 }
 
 Real GaussianTmdSfSet::F_UL_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN_TILDE(WA1, hL, H1perp, g1, Gperp_tilde, +1)
-		+ CONVOLVE_GAUSSIAN_TILDE(WB1, fLperp, D1, h1Lperp, H_tilde, -1);
+	return M_F_UL_SIN_PHIH(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UL_sin_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WAB2, h1Lperp, H1perp);
+	return M_F_UL_SIN_2PHIH(GAUSSIAN);
 }
 
 Real GaussianTmdSfSet::F_UTL_sin_phih_m_phis(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real GaussianTmdSfSet::F_UTT_sin_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE_GAUSSIAN(WB1, f1Tperp, D1);
+	return M_F_UTT_SIN_PHIH_M_PHIS(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UT_sin_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return 0.5*CONVOLVE_GAUSSIAN_TILDE(WAB2, hT, H1perp, g1Tperp, Gperp_tilde, +1)
-		+ 0.5*CONVOLVE_GAUSSIAN_TILDE(WAB2, hTperp, H1perp, f1Tperp, Dperp_tilde, -1)
-		+ CONVOLVE_GAUSSIAN_TILDE(WC2, fTperp, D1, h1Tperp, H_tilde, -1);
+	return M_F_UT_SIN_2PHIH_M_PHIS(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UT_sin_3phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(W3, h1Tperp, H1perp);
+	return M_F_UT_SIN_3PHIH_M_PHIS(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UT_sin_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN_TILDE(W0, fT, D1, h1, H_tilde, -1)
-		- 0.5*CONVOLVE_GAUSSIAN_TILDE(WB2, hT, H1perp, g1Tperp, Gperp_tilde, +1)
-		+ 0.5*CONVOLVE_GAUSSIAN_TILDE(WB2, hTperp, H1perp, f1Tperp, Dperp_tilde, -1);
+	return M_F_UT_SIN_PHIS(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_UT_sin_phih_p_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WA1, h1, H1perp);
+	return M_F_UT_SIN_PHIH_P_PHIS(GAUSSIAN);
 }
 
 Real GaussianTmdSfSet::F_LU_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN_TILDE(WA1, e, H1perp, f1, Gperp_tilde, +1)
-		+ CONVOLVE_GAUSSIAN_TILDE(WB1, gperp, D1, h1perp, E_tilde, +1);
+	return M_F_LU_SIN_PHIH(GAUSSIAN);
 }
 
 Real GaussianTmdSfSet::F_LL(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(W0, g1, D1);
+	return M_F_LL(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_LL_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE_GAUSSIAN_TILDE(WA1, eL, H1perp, g1, Dperp_tilde, -1)
-		- CONVOLVE_GAUSSIAN_TILDE(WB1, gLperp, D1, h1Lperp, E_tilde, +1);
+	return M_F_LL_COS_PHIH(GAUSSIAN);
 }
 
 Real GaussianTmdSfSet::F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WB1, g1Tperp, D1);
+	return M_F_LT_COS_PHIH_M_PHIS(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -0.5*CONVOLVE_GAUSSIAN_TILDE(WAB2, eT, H1perp, g1Tperp, Dperp_tilde, -1)
-		+ 0.5*CONVOLVE_GAUSSIAN_TILDE(WAB2, eTperp, H1perp, f1Tperp, Gperp_tilde, +1)
-		- CONVOLVE_GAUSSIAN_TILDE(WC2, gTperp, D1, h1Tperp, E_tilde, +1);
+	return M_F_LT_COS_2PHIH_M_PHIS(GAUSSIAN);
 }
 Real GaussianTmdSfSet::F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE_GAUSSIAN_TILDE(W0, gT, D1, h1, E_tilde, +1)
-		+ 0.5*CONVOLVE_GAUSSIAN_TILDE(WB2, eT, H1perp, g1Tperp, Dperp_tilde, -1)
-		+ 0.5*CONVOLVE_GAUSSIAN_TILDE(WB2, eTperp, H1perp, f1Tperp, Gperp_tilde, +1);
+	return M_F_LT_COS_PHIS(GAUSSIAN);
 }
 
 // WW-type approximation.
@@ -510,67 +563,60 @@ Real WwTmdSfSet::F_UUL(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real WwTmdSfSet::F_UUT(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(W0, f1, D1);
+	return M_F_UUT_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UU_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*(
-		CONVOLVE(WA1, h, H1perp) - CONVOLVE(WB1, fperp, D1));
+	return M_F_UU_COS_PHIH_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UU_cos_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WAB2, h1perp, H1perp);
+	return M_F_UU_COS_2PHIH_WW(NUMERIC);
 }
 
 Real WwTmdSfSet::F_UL_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE(WA1, hL, H1perp);
+	return M_F_UL_SIN_PHIH_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UL_sin_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WAB2, h1Lperp, H1perp);
+	return M_F_UL_SIN_2PHIH_WW(NUMERIC);
 }
 
 Real WwTmdSfSet::F_UTL_sin_phih_m_phis(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real WwTmdSfSet::F_UTT_sin_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE(WB1, f1Tperp, D1);
+	return M_F_UTT_SIN_PHIH_M_PHIS_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UT_sin_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*(
-		0.5*CONVOLVE(WAB2, hT, H1perp)
-		+ 0.5*CONVOLVE(WAB2, hTperp, H1perp)
-		+ CONVOLVE(WC2, fTperp, D1));
+	return M_F_UT_SIN_2PHIH_M_PHIS_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UT_sin_3phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(W3, h1Tperp, H1perp);
+	return M_F_UT_SIN_3PHIH_M_PHIS_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UT_sin_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*(
-		CONVOLVE(W0, fT, D1)
-		- 0.5*CONVOLVE(WB2, hT, H1perp)
-		+ 0.5*CONVOLVE(WB2, hTperp, H1perp));
+	return M_F_UT_SIN_PHIS_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_UT_sin_phih_p_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WA1, h1, H1perp);
+	return M_F_UT_SIN_PHIH_P_PHIS_WW(NUMERIC);
 }
 
 Real WwTmdSfSet::F_LU_sin_phih(part::Hadron, Real, Real, Real, Real) const {
-	return 0.;
+	return M_F_LU_SIN_PHIH_WW(NUMERIC);
 }
 
 Real WwTmdSfSet::F_LL(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(W0, g1, D1);
+	return M_F_LL_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_LL_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -(2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE(WB1, gLperp, D1);
+	return M_F_LL_COS_PHIH_WW(NUMERIC);
 }
 
 Real WwTmdSfSet::F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE(WB1, g1Tperp, D1);
+	return M_F_LT_COS_PHIH_M_PHIS_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -(2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE(WC2, gTperp, D1);
+	return M_F_LT_COS_2PHIH_M_PHIS_WW(NUMERIC);
 }
 Real WwTmdSfSet::F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -(2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE(W0, gT, D1);
+	return M_F_LT_COS_PHIS_WW(NUMERIC);
 }
 
 // WW-type approximation combined with Gaussian TMDs.
@@ -578,71 +624,59 @@ Real GaussianWwTmdSfSet::F_UUL(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real GaussianWwTmdSfSet::F_UUT(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(W0, f1, D1);
+	return M_F_UUT_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UU_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*(
-		CONVOLVE_GAUSSIAN(WA1, h, H1perp) - CONVOLVE_GAUSSIAN(WB1, fperp, D1));
+	return M_F_UU_COS_PHIH_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UU_cos_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WAB2, h1perp, H1perp);
+	return M_F_UU_COS_2PHIH_WW(GAUSSIAN);
 }
 
 Real GaussianWwTmdSfSet::F_UL_sin_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE_GAUSSIAN(WA1, hL, H1perp);
+	return M_F_UL_SIN_PHIH_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UL_sin_2phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WAB2, h1Lperp, H1perp);
+	return M_F_UL_SIN_2PHIH_WW(GAUSSIAN);
 }
 
 Real GaussianWwTmdSfSet::F_UTL_sin_phih_m_phis(part::Hadron, Real, Real, Real, Real) const {
 	return 0.;
 }
 Real GaussianWwTmdSfSet::F_UTT_sin_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -CONVOLVE_GAUSSIAN(WB1, f1Tperp, D1);
+	return M_F_UTT_SIN_PHIH_M_PHIS_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UT_sin_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	// This follows equation [2.7.8a], but we choose not to simplify using WW-
-	// type approximations because the simplification would involve TMDs
-	// "before" integration, where we have chosen to apply WW-type
-	// approximations only "after" integration. This means that the following
-	// convolution may be less efficient than it could be otherwise.
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*(
-		0.5*CONVOLVE_GAUSSIAN(WAB2, hT, H1perp)
-		+ 0.5*CONVOLVE_GAUSSIAN(WAB2, hTperp, H1perp)
-		+ CONVOLVE_GAUSSIAN(WC2, fTperp, D1));
+	return M_F_UT_SIN_2PHIH_M_PHIS_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UT_sin_3phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(W3, h1Tperp, H1perp);
+	return M_F_UT_SIN_3PHIH_M_PHIS_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UT_sin_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return (2.*mass(target)*x)/std::sqrt(Q_sq)*(
-		CONVOLVE_GAUSSIAN(W0, fT, D1)
-		- 0.5*CONVOLVE_GAUSSIAN(WB2, hT, H1perp)
-		+ 0.5*CONVOLVE_GAUSSIAN(WB2, hTperp, H1perp));
+	return M_F_UT_SIN_PHIS_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_UT_sin_phih_p_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WA1, h1, H1perp);
+	return M_F_UT_SIN_PHIH_P_PHIS_WW(GAUSSIAN);
 }
 
 Real GaussianWwTmdSfSet::F_LU_sin_phih(part::Hadron, Real, Real, Real, Real) const {
-	return 0.;
+	return M_F_LU_SIN_PHIH_WW(GAUSSIAN);
 }
 
 Real GaussianWwTmdSfSet::F_LL(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(W0, g1, D1);
+	return M_F_LL_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_LL_cos_phih(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -(2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE_GAUSSIAN(WB1, gLperp, D1);
+	return M_F_LL_COS_PHIH_WW(GAUSSIAN);
 }
 
 Real GaussianWwTmdSfSet::F_LT_cos_phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return CONVOLVE_GAUSSIAN(WB1, g1Tperp, D1);
+	return M_F_LT_COS_PHIH_M_PHIS_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_LT_cos_2phih_m_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -(2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE_GAUSSIAN(WC2, gTperp, D1);
+	return M_F_LT_COS_2PHIH_M_PHIS_WW(GAUSSIAN);
 }
 Real GaussianWwTmdSfSet::F_LT_cos_phis(part::Hadron h, Real x, Real z, Real Q_sq, Real ph_t_sq) const {
-	return -(2.*mass(target)*x)/std::sqrt(Q_sq)*CONVOLVE_GAUSSIAN(W0, gT, D1);
+	return M_F_LT_COS_PHIS_WW(GAUSSIAN);
 }
 

--- a/src/structure_function.cpp
+++ b/src/structure_function.cpp
@@ -258,7 +258,7 @@ Real convolve_gaussian(
 		break;
 	default:
 		// Unknown integrand.
-		weight = 0.;
+		weight = FlavorVec(tmd_set.flavor_count);
 	}
 	result += (sq_vec(tmd_set.charges)*weight*gaussian*tmd*ff).sum();
 	return result;

--- a/src/structure_function.cpp
+++ b/src/structure_function.cpp
@@ -195,7 +195,7 @@ Real convolve_numeric(
 			case Weight::W3:
 				weight = (
 					4.*dot_p_perp*sq(dot_k_perp)
-					- dot_k_perp*dot_p_k_perp
+					- 2.*dot_k_perp*dot_p_k_perp
 					- dot_p_perp*k_perp_sq)/(2.*z*sq(M)*mh);
 				break;
 			default:

--- a/src/tmd.cpp
+++ b/src/tmd.cpp
@@ -178,12 +178,12 @@ GaussianTmdVars::GaussianTmdVars(GaussianWwTmdVars const& ww_vars) :
 	Gperp_tilde(f1.size(), INF),
 	E_tilde(f1.size(), INF) { }
 
-#define FILL_AND_CHECK_TMD_VAR(f) do { \
-	if (vars.f.size() == 1) { \
-		vars.f = FlavorVec(flavor_count, vars.f[0]); \
+#define FILL_AND_CHECK_TMD_VAR(tmd) do { \
+	if (vars.tmd.size() == 1) { \
+		vars.tmd = FlavorVec(flavor_count, vars.tmd[0]); \
 	} \
-	if (vars.f.size() != flavor_count) { \
-		throw FlavorVecUnexpectedSize(vars.f.size(), flavor_count); \
+	if (vars.tmd.size() != flavor_count) { \
+		throw FlavorVecUnexpectedSize(vars.tmd.size(), flavor_count); \
 	} \
 } while (false)
 

--- a/src/tmd.cpp
+++ b/src/tmd.cpp
@@ -8,10 +8,10 @@
 using namespace sidis;
 using namespace sidis::sf;
 
-TmdSet::TmdSet(unsigned flavor_count, FlavorVec const& charges, part::Nucleus target) :
+TmdSet::TmdSet(part::Nucleus target, unsigned flavor_count, FlavorVec const& charges) :
+		target(target),
 		flavor_count(flavor_count),
-		charges(charges),
-		target(target) {
+		charges(charges) {
 	if (!(flavor_count < MAX_FLAVOR_VEC_SIZE)) {
 		throw FlavorOutOfRange(flavor_count);
 	}
@@ -197,11 +197,11 @@ GaussianTmdVars fill_vars(unsigned flavor_count, GaussianTmdVars vars) {
 
 // Gaussian approximation.
 GaussianTmdSet::GaussianTmdSet(
+		part::Nucleus target,
 		unsigned flavor_count,
 		FlavorVec const& charges,
-		part::Nucleus target,
 		GaussianTmdVars const& vars) :
-		TmdSet(flavor_count, charges, target),
+		TmdSet(target, flavor_count, charges),
 		vars(fill_vars(flavor_count, vars)) { }
 
 FlavorVec GaussianTmdSet::xf1(Real, Real) const {
@@ -506,11 +506,11 @@ FlavorVec WwTmdSet::E_tilde(part::Hadron, Real, Real, Real) const {
 
 // Gaussian and WW-type approximation combined.
 GaussianWwTmdSet::GaussianWwTmdSet(
+	part::Nucleus target,
 	unsigned flavor_count,
 	FlavorVec const& charges,
-	part::Nucleus target,
 	GaussianWwTmdVars const& vars) :
-	GaussianTmdSet(flavor_count, charges, target, GaussianTmdVars(vars)) { }
+	GaussianTmdSet(target, flavor_count, charges, GaussianTmdVars(vars)) { }
 
 FlavorVec GaussianWwTmdSet::xf1(Real, Real) const {
 	return FlavorVec(flavor_count);

--- a/src/tmd.cpp
+++ b/src/tmd.cpp
@@ -1,797 +1,682 @@
 #include "sidis/tmd.hpp"
 
 #include <cmath>
-#include <vector>
+
+#include "sidis/extra/exception.hpp"
 
 using namespace sidis;
 using namespace sidis::sf;
 
-namespace {
-
-Real gaussian(Real k_perp_sq, Real mean) {
-	return std::exp(-k_perp_sq/mean)/(PI*mean);
-}
-
+TmdSet::TmdSet(unsigned flavor_count, FlavorVec const& charges, part::Nucleus target) :
+		flavor_count(flavor_count),
+		charges(charges),
+		target(target) {
+	if (!(flavor_count < MAX_FLAVOR_VEC_SIZE)) {
+		throw FlavorOutOfRange(flavor_count);
+	}
+	if (charges.size() != flavor_count) {
+		throw FlavorVecUnexpectedSize(charges.size(), flavor_count);
+	}
 }
 
 // Standard TMDs.
-Real TmdSet::xf1(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xf1(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xf1Tperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xf1Tperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xfT(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xfT(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xfperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xfperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xfLperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xfLperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xfTperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xfTperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xg1(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xg1(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xg1Tperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xg1Tperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xgT(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xgT(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xgperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xgperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xgLperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xgLperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xgTperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xgTperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xh1(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xh1(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xh1perp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xh1perp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xh1Lperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xh1Lperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xh1Tperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xh1Tperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xh(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xh(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xhL(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xhL(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xhT(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xhT(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xhTperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xhTperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xe(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xe(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xeL(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xeL(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xeT(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xeT(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::xeTperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::xeTperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real TmdSet::D1(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::D1(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::H1perp(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::H1perp(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::Dperp_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::Dperp_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::H_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::H_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::Gperp_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::Gperp_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real TmdSet::E_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec TmdSet::E_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+
+GaussianTmdVars::GaussianTmdVars() :
+	f1(1, INF),
+	f1Tperp(1, INF),
+	fT(1, INF),
+	fperp(1, INF),
+	fLperp(1, INF),
+	fTperp(1, INF),
+	g1(1, INF),
+	g1Tperp(1, INF),
+	gT(1, INF),
+	gperp(1, INF),
+	gLperp(1, INF),
+	gTperp(1, INF),
+	h1(1, INF),
+	h1perp(1, INF),
+	h1Lperp(1, INF),
+	h1Tperp(1, INF),
+	h(1, INF),
+	hL(1, INF),
+	hT(1, INF),
+	hTperp(1, INF),
+	e(1, INF),
+	eL(1, INF),
+	eT(1, INF),
+	eTperp(1, INF),
+	D1(1, INF),
+	H1perp(1, INF),
+	Dperp_tilde(1, INF),
+	H_tilde(1, INF),
+	Gperp_tilde(1, INF),
+	E_tilde(1, INF) { }
+
+GaussianTmdVars::GaussianTmdVars(GaussianWwTmdVars const& ww_vars) :
+	// We choose infinity for the width of the structure functions that are to
+	// be neglected.
+	f1(ww_vars.f1),
+	f1Tperp(ww_vars.f1Tperp),
+	fT(ww_vars.fT),
+	fperp(ww_vars.f1),
+	fLperp(f1.size(), INF),
+	fTperp(ww_vars.f1Tperp),
+	g1(ww_vars.g1),
+	g1Tperp(ww_vars.g1Tperp),
+	gT(ww_vars.gT),
+	gperp(f1.size(), INF),
+	gLperp(ww_vars.g1),
+	gTperp(ww_vars.g1Tperp),
+	h1(ww_vars.h1),
+	h1perp(ww_vars.h1perp),
+	h1Lperp(ww_vars.h1Lperp),
+	h1Tperp(ww_vars.h1Tperp),
+	h(ww_vars.h),
+	hL(ww_vars.hL),
+	hT(ww_vars.hT),
+	hTperp(ww_vars.hTperp),
+	e(f1.size(), INF),
+	eL(f1.size(), INF),
+	eT(f1.size(), INF),
+	eTperp(f1.size(), INF),
+	D1(ww_vars.D1),
+	H1perp(ww_vars.H1perp),
+	Dperp_tilde(f1.size(), INF),
+	H_tilde(f1.size(), INF),
+	Gperp_tilde(f1.size(), INF),
+	E_tilde(f1.size(), INF) { }
+
+#define FILL_AND_CHECK_TMD_VAR(f) do { \
+	if (vars.f.size() == 1) { \
+		vars.f = FlavorVec(flavor_count, vars.f[0]); \
+	} \
+	if (vars.f.size() != flavor_count) { \
+		throw FlavorVecUnexpectedSize(vars.f.size(), flavor_count); \
+	} \
+} while (false)
+
+namespace {
+// Checks that all of the variances have one entry for every flavor. If any
+// variances have only a single entry, then that entry is copied `flavor_count`
+// times. Otherwise, an exception is thrown.
+GaussianTmdVars fill_vars(unsigned flavor_count, GaussianTmdVars vars) {
+	FILL_AND_CHECK_TMD_VAR(f1);
+	FILL_AND_CHECK_TMD_VAR(f1Tperp);
+	FILL_AND_CHECK_TMD_VAR(fT);
+	FILL_AND_CHECK_TMD_VAR(fperp);
+	FILL_AND_CHECK_TMD_VAR(fLperp);
+	FILL_AND_CHECK_TMD_VAR(fTperp);
+	FILL_AND_CHECK_TMD_VAR(g1);
+	FILL_AND_CHECK_TMD_VAR(g1Tperp);
+	FILL_AND_CHECK_TMD_VAR(gT);
+	FILL_AND_CHECK_TMD_VAR(gperp);
+	FILL_AND_CHECK_TMD_VAR(gLperp);
+	FILL_AND_CHECK_TMD_VAR(gTperp);
+	FILL_AND_CHECK_TMD_VAR(h1);
+	FILL_AND_CHECK_TMD_VAR(h1perp);
+	FILL_AND_CHECK_TMD_VAR(h1Lperp);
+	FILL_AND_CHECK_TMD_VAR(h1Tperp);
+	FILL_AND_CHECK_TMD_VAR(h);
+	FILL_AND_CHECK_TMD_VAR(hL);
+	FILL_AND_CHECK_TMD_VAR(hT);
+	FILL_AND_CHECK_TMD_VAR(hTperp);
+	FILL_AND_CHECK_TMD_VAR(e);
+	FILL_AND_CHECK_TMD_VAR(eL);
+	FILL_AND_CHECK_TMD_VAR(eT);
+	FILL_AND_CHECK_TMD_VAR(eTperp);
+	FILL_AND_CHECK_TMD_VAR(D1);
+	FILL_AND_CHECK_TMD_VAR(H1perp);
+	FILL_AND_CHECK_TMD_VAR(Dperp_tilde);
+	FILL_AND_CHECK_TMD_VAR(H_tilde);
+	FILL_AND_CHECK_TMD_VAR(Gperp_tilde);
+	FILL_AND_CHECK_TMD_VAR(E_tilde);
+	return vars;
+}
 }
 
 // Gaussian approximation.
 GaussianTmdSet::GaussianTmdSet(
-	unsigned flavor_count,
-	part::Nucleus target,
-	Real mean_f1,
-	Real mean_f1Tperp,
-	Real mean_fT,
-	Real mean_fperp,
-	Real mean_fLperp,
-	Real mean_fTperp,
-	Real mean_g1,
-	Real mean_g1Tperp,
-	Real mean_gT,
-	Real mean_gperp,
-	Real mean_gLperp,
-	Real mean_gTperp,
-	Real mean_h1,
-	Real mean_h1perp,
-	Real mean_h1Lperp,
-	Real mean_h1Tperp,
-	Real mean_h,
-	Real mean_hL,
-	Real mean_hT,
-	Real mean_hTperp,
-	Real mean_e,
-	Real mean_eL,
-	Real mean_eT,
-	Real mean_eTperp,
-	Real mean_D1,
-	Real mean_H1perp,
-	Real mean_Dperp_tilde,
-	Real mean_H_tilde,
-	Real mean_Gperp_tilde,
-	Real mean_E_tilde) :
-	TmdSet(flavor_count, target),
-	mean_f1(flavor_count, mean_f1),
-	mean_f1Tperp(flavor_count, mean_f1Tperp),
-	mean_fT(flavor_count, mean_fT),
-	mean_fperp(flavor_count, mean_fperp),
-	mean_fLperp(flavor_count, mean_fLperp),
-	mean_fTperp(flavor_count, mean_fTperp),
-	mean_g1(flavor_count, mean_g1),
-	mean_g1Tperp(flavor_count, mean_g1Tperp),
-	mean_gT(flavor_count, mean_gT),
-	mean_gperp(flavor_count, mean_gperp),
-	mean_gLperp(flavor_count, mean_gLperp),
-	mean_gTperp(flavor_count, mean_gTperp),
-	mean_h1(flavor_count, mean_h1),
-	mean_h1perp(flavor_count, mean_h1perp),
-	mean_h1Lperp(flavor_count, mean_h1Lperp),
-	mean_h1Tperp(flavor_count, mean_h1Tperp),
-	mean_h(flavor_count, mean_h),
-	mean_hL(flavor_count, mean_hL),
-	mean_hT(flavor_count, mean_hT),
-	mean_hTperp(flavor_count, mean_hTperp),
-	mean_e(flavor_count, mean_e),
-	mean_eL(flavor_count, mean_eL),
-	mean_eT(flavor_count, mean_eT),
-	mean_eTperp(flavor_count, mean_eTperp),
-	mean_D1(flavor_count, mean_D1),
-	mean_H1perp(flavor_count, mean_H1perp),
-	mean_Dperp_tilde(flavor_count, mean_Dperp_tilde),
-	mean_H_tilde(flavor_count, mean_H_tilde),
-	mean_Gperp_tilde(flavor_count, mean_Gperp_tilde),
-	mean_E_tilde(flavor_count, mean_E_tilde) { }
-GaussianTmdSet::GaussianTmdSet(
-	unsigned flavor_count,
-	part::Nucleus target,
-	Real const* mean_f1,
-	Real const* mean_f1Tperp,
-	Real const* mean_fT,
-	Real const* mean_fperp,
-	Real const* mean_fLperp,
-	Real const* mean_fTperp,
-	Real const* mean_g1,
-	Real const* mean_g1Tperp,
-	Real const* mean_gT,
-	Real const* mean_gperp,
-	Real const* mean_gLperp,
-	Real const* mean_gTperp,
-	Real const* mean_h1,
-	Real const* mean_h1perp,
-	Real const* mean_h1Lperp,
-	Real const* mean_h1Tperp,
-	Real const* mean_h,
-	Real const* mean_hL,
-	Real const* mean_hT,
-	Real const* mean_hTperp,
-	Real const* mean_e,
-	Real const* mean_eL,
-	Real const* mean_eT,
-	Real const* mean_eTperp,
-	Real const* mean_D1,
-	Real const* mean_H1perp,
-	Real const* mean_Dperp_tilde,
-	Real const* mean_H_tilde,
-	Real const* mean_Gperp_tilde,
-	Real const* mean_E_tilde) :
-	TmdSet(flavor_count, target),
-	mean_f1(mean_f1, mean_f1 + flavor_count),
-	mean_f1Tperp(mean_f1Tperp, mean_f1Tperp + flavor_count),
-	mean_fT(mean_fT, mean_fT + flavor_count),
-	mean_fperp(mean_fperp, mean_fperp + flavor_count),
-	mean_fLperp(mean_fLperp, mean_fLperp + flavor_count),
-	mean_fTperp(mean_fTperp, mean_fTperp + flavor_count),
-	mean_g1(mean_g1, mean_g1 + flavor_count),
-	mean_g1Tperp(mean_g1Tperp, mean_g1Tperp + flavor_count),
-	mean_gT(mean_gT, mean_gT + flavor_count),
-	mean_gperp(mean_gperp, mean_gperp + flavor_count),
-	mean_gLperp(mean_gLperp, mean_gLperp + flavor_count),
-	mean_gTperp(mean_gTperp, mean_gTperp + flavor_count),
-	mean_h1(mean_h1, mean_h1 + flavor_count),
-	mean_h1perp(mean_h1perp, mean_h1perp + flavor_count),
-	mean_h1Lperp(mean_h1Lperp, mean_h1Lperp + flavor_count),
-	mean_h1Tperp(mean_h1Tperp, mean_h1Tperp + flavor_count),
-	mean_h(mean_h, mean_h + flavor_count),
-	mean_hL(mean_hL, mean_hL + flavor_count),
-	mean_hT(mean_hT, mean_hT + flavor_count),
-	mean_hTperp(mean_hTperp, mean_hTperp + flavor_count),
-	mean_e(mean_e, mean_e + flavor_count),
-	mean_eL(mean_eL, mean_eL + flavor_count),
-	mean_eT(mean_eT, mean_eT + flavor_count),
-	mean_eTperp(mean_eTperp, mean_eTperp + flavor_count),
-	mean_D1(mean_D1, mean_D1 + flavor_count),
-	mean_H1perp(mean_H1perp, mean_H1perp + flavor_count),
-	mean_Dperp_tilde(mean_Dperp_tilde, mean_Dperp_tilde + flavor_count),
-	mean_H_tilde(mean_H_tilde, mean_H_tilde + flavor_count),
-	mean_Gperp_tilde(mean_Gperp_tilde, mean_Gperp_tilde + flavor_count),
-	mean_E_tilde(mean_E_tilde, mean_E_tilde + flavor_count) { }
+		unsigned flavor_count,
+		FlavorVec const& charges,
+		part::Nucleus target,
+		GaussianTmdVars const& vars) :
+		TmdSet(flavor_count, charges, target),
+		vars(fill_vars(flavor_count, vars)) { }
 
-Real GaussianTmdSet::xf1(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xf1(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xf1Tperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xf1Tperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xfT(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xfT(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xfperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xfperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xfLperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xfLperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xfTperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xfTperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xg1(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xg1(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xg1Tperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xg1Tperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xgT(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xgT(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xgperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xgperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xgLperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xgLperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xgTperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xgTperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xh1(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xh1(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xh1perp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xh1perp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xh1Lperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xh1Lperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xh1Tperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xh1Tperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xh(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xh(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xhL(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xhL(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xhT(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xhT(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xhTperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xhTperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xe(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xe(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xeL(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xeL(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xeT(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xeT(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::xeTperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::xeTperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real GaussianTmdSet::D1(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::D1(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::H1perp(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::H1perp(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::Dperp_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::Dperp_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::H_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::H_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::Gperp_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianTmdSet::Gperp_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianTmdSet::E_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
-}
-
-Real GaussianTmdSet::xf1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xf1(fl, x, Q_sq)*gaussian(k_perp_sq, mean_f1[fl]);
-}
-Real GaussianTmdSet::xf1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xf1Tperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_f1Tperp[fl]);
-}
-Real GaussianTmdSet::xfT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xfT(fl, x, Q_sq)*gaussian(k_perp_sq, mean_fT[fl]);
-}
-Real GaussianTmdSet::xfperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xfperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_fperp[fl]);
-}
-Real GaussianTmdSet::xfLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xfLperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_fLperp[fl]);
-}
-Real GaussianTmdSet::xfTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xfTperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_fTperp[fl]);
-}
-Real GaussianTmdSet::xg1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xg1(fl, x, Q_sq)*gaussian(k_perp_sq, mean_g1[fl]);
-}
-Real GaussianTmdSet::xg1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xg1Tperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_g1Tperp[fl]);
-}
-Real GaussianTmdSet::xgT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xgT(fl, x, Q_sq)*gaussian(k_perp_sq, mean_gT[fl]);
-}
-Real GaussianTmdSet::xgperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xgperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_gperp[fl]);
-}
-Real GaussianTmdSet::xgLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xgLperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_gLperp[fl]);
-}
-Real GaussianTmdSet::xgTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xgTperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_gTperp[fl]);
-}
-Real GaussianTmdSet::xh1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xh1(fl, x, Q_sq)*gaussian(k_perp_sq, mean_h1[fl]);
-}
-Real GaussianTmdSet::xh1perp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xh1perp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_h1perp[fl]);
-}
-Real GaussianTmdSet::xh1Lperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xh1Lperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_h1Lperp[fl]);
-}
-Real GaussianTmdSet::xh1Tperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xh1Tperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_h1Tperp[fl]);
-}
-Real GaussianTmdSet::xh(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xh(fl, x, Q_sq)*gaussian(k_perp_sq, mean_h[fl]);
-}
-Real GaussianTmdSet::xhL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xhL(fl, x, Q_sq)*gaussian(k_perp_sq, mean_hL[fl]);
-}
-Real GaussianTmdSet::xhT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xhT(fl, x, Q_sq)*gaussian(k_perp_sq, mean_hT[fl]);
-}
-Real GaussianTmdSet::xhTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xhTperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_hTperp[fl]);
-}
-Real GaussianTmdSet::xe(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xe(fl, x, Q_sq)*gaussian(k_perp_sq, mean_e[fl]);
-}
-Real GaussianTmdSet::xeL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xeL(fl, x, Q_sq)*gaussian(k_perp_sq, mean_eL[fl]);
-}
-Real GaussianTmdSet::xeT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xeT(fl, x, Q_sq)*gaussian(k_perp_sq, mean_eT[fl]);
-}
-Real GaussianTmdSet::xeTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xeTperp(fl, x, Q_sq)*gaussian(k_perp_sq, mean_eTperp[fl]);
+FlavorVec GaussianTmdSet::E_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real GaussianTmdSet::D1(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const {
-	return D1(h, fl, z, Q_sq)*gaussian(p_perp_sq, mean_D1[fl]);
+FlavorVec GaussianTmdSet::xf1(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.f1, k_perp_sq)*xf1(x, Q_sq);
 }
-Real GaussianTmdSet::H1perp(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const {
-	return H1perp(h, fl, z, Q_sq)*gaussian(p_perp_sq, mean_H1perp[fl]);
+FlavorVec GaussianTmdSet::xf1Tperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.f1Tperp, k_perp_sq)*xf1Tperp(x, Q_sq);
 }
-Real GaussianTmdSet::Dperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const {
-	return Dperp_tilde(h, fl, z, Q_sq)*gaussian(p_perp_sq, mean_Dperp_tilde[fl]);
+FlavorVec GaussianTmdSet::xfT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.fT, k_perp_sq)*xfT(x, Q_sq);
 }
-Real GaussianTmdSet::H_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const {
-	return H_tilde(h, fl, z, Q_sq)*gaussian(p_perp_sq, mean_H_tilde[fl]);
+FlavorVec GaussianTmdSet::xfperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.fperp, k_perp_sq)*xfperp(x, Q_sq);
 }
-Real GaussianTmdSet::Gperp_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const {
-	return Gperp_tilde(h, fl, z, Q_sq)*gaussian(p_perp_sq, mean_Gperp_tilde[fl]);
+FlavorVec GaussianTmdSet::xfLperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.fLperp, k_perp_sq)*xfLperp(x, Q_sq);
 }
-Real GaussianTmdSet::E_tilde(part::Hadron h, unsigned fl, Real z, Real Q_sq, Real p_perp_sq) const {
-	return E_tilde(h, fl, z, Q_sq)*gaussian(p_perp_sq, mean_E_tilde[fl]);
+FlavorVec GaussianTmdSet::xfTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.fTperp, k_perp_sq)*xfTperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xg1(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.g1, k_perp_sq)*xg1(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xg1Tperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.g1Tperp, k_perp_sq)*xg1Tperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xgT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.gT, k_perp_sq)*xgT(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xgperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.gperp, k_perp_sq)*xgperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xgLperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.gLperp, k_perp_sq)*xgLperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xgTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.gTperp, k_perp_sq)*xgTperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xh1(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.h1, k_perp_sq)*xh1(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xh1perp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.h1perp, k_perp_sq)*xh1perp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xh1Lperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.h1Lperp, k_perp_sq)*xh1Lperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xh1Tperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.h1Tperp, k_perp_sq)*xh1Tperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xh(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.h, k_perp_sq)*xh(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xhL(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.hL, k_perp_sq)*xhL(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xhT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.hT, k_perp_sq)*xhT(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xhTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.hTperp, k_perp_sq)*xhTperp(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xe(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.e, k_perp_sq)*xe(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xeL(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.eL, k_perp_sq)*xeL(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xeT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.eT, k_perp_sq)*xeT(x, Q_sq);
+}
+FlavorVec GaussianTmdSet::xeTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return tmd_gaussian_factor(vars.eTperp, k_perp_sq)*xeTperp(x, Q_sq);
+}
+
+FlavorVec GaussianTmdSet::D1(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const {
+	return tmd_gaussian_factor(vars.D1, p_perp_sq)*D1(h, z, Q_sq);
+}
+FlavorVec GaussianTmdSet::H1perp(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const {
+	return tmd_gaussian_factor(vars.H1perp, p_perp_sq)*H1perp(h, z, Q_sq);
+}
+FlavorVec GaussianTmdSet::Dperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const {
+	return tmd_gaussian_factor(vars.Dperp_tilde, p_perp_sq)*Dperp_tilde(h, z, Q_sq);
+}
+FlavorVec GaussianTmdSet::H_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const {
+	return tmd_gaussian_factor(vars.H_tilde, p_perp_sq)*H_tilde(h, z, Q_sq);
+}
+FlavorVec GaussianTmdSet::Gperp_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const {
+	return tmd_gaussian_factor(vars.Gperp_tilde, p_perp_sq)*Gperp_tilde(h, z, Q_sq);
+}
+FlavorVec GaussianTmdSet::E_tilde(part::Hadron h, Real z, Real Q_sq, Real p_perp_sq) const {
+	return tmd_gaussian_factor(vars.E_tilde, p_perp_sq)*E_tilde(h, z, Q_sq);
 }
 
 // WW-type approximation.
-Real WwTmdSet::xf1(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xf1(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xf1Tperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xf1Tperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xg1(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xg1(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xg1Tperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xg1Tperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xh1(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xh1(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xh1perp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xh1perp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xh1Lperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xh1Lperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xh1Tperp(unsigned, Real, Real, Real) const {
-	return 0.;
-}
-
-Real WwTmdSet::D1(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
-}
-Real WwTmdSet::H1perp(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xh1Tperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real WwTmdSet::xf1TperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	Real M = mass(target);
-	return k_perp_sq/(2.*M*M)*xf1Tperp(fl, x, Q_sq, k_perp_sq);
+FlavorVec WwTmdSet::D1(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::xg1TperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	Real M = mass(target);
-	return k_perp_sq/(2.*M*M)*xg1Tperp(fl, x, Q_sq, k_perp_sq);
-}
-Real WwTmdSet::xh1perpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	Real M = mass(target);
-	return k_perp_sq/(2.*M*M)*xh1perp(fl, x, Q_sq, k_perp_sq);
-}
-Real WwTmdSet::xh1LperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	Real M = mass(target);
-	return k_perp_sq/(2.*M*M)*xh1Lperp(fl, x, Q_sq, k_perp_sq);
-}
-Real WwTmdSet::xh1TperpM1(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	Real M = mass(target);
-	return k_perp_sq/(2.*M*M)*xh1Tperp(fl, x, Q_sq, k_perp_sq);
+FlavorVec WwTmdSet::H1perp(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real WwTmdSet::xfT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return -xf1TperpM1(fl, x, Q_sq, k_perp_sq)/x;
+FlavorVec WwTmdSet::xf1TperpM1(Real x, Real Q_sq, Real k_perp_sq) const {
+	Real M = mass(target);
+	return (k_perp_sq/(2*M*M))*xf1Tperp(x, Q_sq, k_perp_sq);
 }
-Real WwTmdSet::xfperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xf1(fl, x, Q_sq, k_perp_sq)/x;
+FlavorVec WwTmdSet::xg1TperpM1(Real x, Real Q_sq, Real k_perp_sq) const {
+	Real M = mass(target);
+	return (k_perp_sq/(2*M*M))*xg1Tperp(x, Q_sq, k_perp_sq);
 }
-Real WwTmdSet::xfLperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xh1perpM1(Real x, Real Q_sq, Real k_perp_sq) const {
+	Real M = mass(target);
+	return (k_perp_sq/(2*M*M))*xh1perp(x, Q_sq, k_perp_sq);
 }
-Real WwTmdSet::xfTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xf1Tperp(fl, x, Q_sq, k_perp_sq)/x;
+FlavorVec WwTmdSet::xh1LperpM1(Real x, Real Q_sq, Real k_perp_sq) const {
+	Real M = mass(target);
+	return (k_perp_sq/(2*M*M))*xh1Lperp(x, Q_sq, k_perp_sq);
 }
-Real WwTmdSet::xgT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xg1TperpM1(fl, x, Q_sq, k_perp_sq)/x;
-}
-Real WwTmdSet::xgperp(unsigned, Real, Real, Real) const {
-	return 0.;
-}
-Real WwTmdSet::xgLperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xg1(fl, x, Q_sq, k_perp_sq)/x;
-}
-Real WwTmdSet::xgTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return xg1Tperp(fl, x, Q_sq, k_perp_sq)/x;
-}
-Real WwTmdSet::xh(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return -2.*xh1perpM1(fl, x, Q_sq, k_perp_sq)/x;
-}
-Real WwTmdSet::xhL(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return -2.*xh1LperpM1(fl, x, Q_sq, k_perp_sq)/x;
-}
-Real WwTmdSet::xhT(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return -(xh1(fl, x, Q_sq, k_perp_sq) + xh1TperpM1(fl, x, Q_sq, k_perp_sq))/x;
-}
-Real WwTmdSet::xhTperp(unsigned fl, Real x, Real Q_sq, Real k_perp_sq) const {
-	return (xh1(fl, x, Q_sq, k_perp_sq) - xh1TperpM1(fl, x, Q_sq, k_perp_sq))/x;
-}
-Real WwTmdSet::xe(unsigned, Real, Real, Real) const {
-	return 0.;
-}
-Real WwTmdSet::xeL(unsigned, Real, Real, Real) const {
-	return 0.;
-}
-Real WwTmdSet::xeT(unsigned, Real, Real, Real) const {
-	return 0.;
-}
-Real WwTmdSet::xeTperp(unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xh1TperpM1(Real x, Real Q_sq, Real k_perp_sq) const {
+	Real M = mass(target);
+	return (k_perp_sq/(2*M*M))*xh1Tperp(x, Q_sq, k_perp_sq);
 }
 
-Real WwTmdSet::Dperp_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xfT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return -xf1TperpM1(x, Q_sq, k_perp_sq)/x;
 }
-Real WwTmdSet::H_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xfperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return xf1(x, Q_sq, k_perp_sq)/x;
 }
-Real WwTmdSet::Gperp_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xfLperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real WwTmdSet::E_tilde(part::Hadron, unsigned, Real, Real, Real) const {
-	return 0.;
+FlavorVec WwTmdSet::xfTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return xf1Tperp(x, Q_sq, k_perp_sq)/x;
 }
+FlavorVec WwTmdSet::xgT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return xg1TperpM1(x, Q_sq, k_perp_sq)/x;
+}
+FlavorVec WwTmdSet::xgperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::xgLperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return xg1(x, Q_sq, k_perp_sq)/x;
+}
+FlavorVec WwTmdSet::xgTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return xg1Tperp(x, Q_sq, k_perp_sq)/x;
+}
+FlavorVec WwTmdSet::xh(Real x, Real Q_sq, Real k_perp_sq) const {
+	return -2.*xh1perpM1(x, Q_sq, k_perp_sq)/x;
+}
+FlavorVec WwTmdSet::xhL(Real x, Real Q_sq, Real k_perp_sq) const {
+	return -2.*xh1LperpM1(x, Q_sq, k_perp_sq)/x;
+}
+FlavorVec WwTmdSet::xhT(Real x, Real Q_sq, Real k_perp_sq) const {
+	return -(xh1(x, Q_sq, k_perp_sq) + xh1TperpM1(x, Q_sq, k_perp_sq))/x;
+}
+FlavorVec WwTmdSet::xhTperp(Real x, Real Q_sq, Real k_perp_sq) const {
+	return (xh1(x, Q_sq, k_perp_sq) - xh1TperpM1(x, Q_sq, k_perp_sq))/x;
+}
+FlavorVec WwTmdSet::xe(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::xeL(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::xeT(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::xeTperp(Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+
+FlavorVec WwTmdSet::Dperp_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::H_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::Gperp_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+FlavorVec WwTmdSet::E_tilde(part::Hadron, Real, Real, Real) const {
+	return FlavorVec(flavor_count);
+}
+
+GaussianWwTmdVars::GaussianWwTmdVars() :
+	f1(1, INF),
+	f1Tperp(1, INF),
+	fT(1, INF),
+	g1(1, INF),
+	g1Tperp(1, INF),
+	gT(1, INF),
+	h1(1, INF),
+	h1perp(1, INF),
+	h1Lperp(1, INF),
+	h1Tperp(1, INF),
+	h(1, INF),
+	hL(1, INF),
+	hT(1, INF),
+	hTperp(1, INF),
+	D1(1, INF),
+	H1perp(1, INF) { }
 
 // Gaussian and WW-type approximation combined.
 GaussianWwTmdSet::GaussianWwTmdSet(
 	unsigned flavor_count,
+	FlavorVec const& charges,
 	part::Nucleus target,
-	Real mean_f1,
-	Real mean_f1Tperp,
-	Real mean_fT,
-	Real mean_g1,
-	Real mean_g1Tperp,
-	Real mean_gT,
-	Real mean_h1,
-	Real mean_h1perp,
-	Real mean_h1Lperp,
-	Real mean_h1Tperp,
-	Real mean_h,
-	Real mean_hL,
-	Real mean_hT,
-	Real mean_hTperp,
-	Real mean_D1,
-	Real mean_H1perp) :
-	// We choose infinity for the width of the structure functions that are to
-	// be neglected.
-	GaussianTmdSet(
-		flavor_count,
-		target,
-		mean_f1,
-		mean_f1Tperp,
-		mean_fT,
-		// `mean_fperp`
-		mean_f1,
-		// `mean_fLperp`
-		INF,
-		// `mean_fTperp`
-		mean_f1Tperp,
-		mean_g1,
-		mean_g1Tperp,
-		mean_gT,
-		// `mean_gperp`
-		INF,
-		// `mean_gLperp`
-		mean_g1,
-		// `mean_gTperp`
-		mean_g1Tperp,
-		mean_h1,
-		mean_h1perp,
-		mean_h1Lperp,
-		mean_h1Tperp,
-		mean_h,
-		mean_hL,
-		mean_hT,
-		mean_hTperp,
-		// `mean_e`
-		INF,
-		// `mean_eL`
-		INF,
-		// `mean_eT`
-		INF,
-		// `mean_eTperp`
-		INF,
-		mean_D1,
-		mean_H1perp,
-		// `mean_Dperp_tilde`
-		INF,
-		// `mean_H_tilde`
-		INF,
-		// `mean_Gperp_tilde`
-		INF,
-		// `mean_E_tilde`
-		INF) { }
-// Gaussian and WW-type approximation combined.
-GaussianWwTmdSet::GaussianWwTmdSet(
-	unsigned flavor_count,
-	part::Nucleus target,
-	Real const* mean_f1,
-	Real const* mean_f1Tperp,
-	Real const* mean_fT,
-	Real const* mean_g1,
-	Real const* mean_g1Tperp,
-	Real const* mean_gT,
-	Real const* mean_h1,
-	Real const* mean_h1perp,
-	Real const* mean_h1Lperp,
-	Real const* mean_h1Tperp,
-	Real const* mean_h,
-	Real const* mean_hL,
-	Real const* mean_hT,
-	Real const* mean_hTperp,
-	Real const* mean_D1,
-	Real const* mean_H1perp) :
-	// We choose infinity for the width of the structure functions that are to
-	// be neglected.
-	GaussianTmdSet(
-		flavor_count,
-		target,
-		mean_f1,
-		mean_f1Tperp,
-		mean_fT,
-		// `mean_fperp`
-		mean_f1,
-		// `mean_fLperp`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_fTperp`
-		mean_f1Tperp,
-		mean_g1,
-		mean_g1Tperp,
-		mean_gT,
-		// `mean_gperp`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_gLperp`
-		mean_g1,
-		// `mean_gTperp`
-		mean_g1Tperp,
-		mean_h1,
-		mean_h1perp,
-		mean_h1Lperp,
-		mean_h1Tperp,
-		mean_h,
-		mean_hL,
-		mean_hT,
-		mean_hTperp,
-		// `mean_e`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_eL`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_eT`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_eTperp`
-		std::vector<Real>(flavor_count, INF).data(),
-		mean_D1,
-		mean_H1perp,
-		// `mean_Dperp_tilde`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_H_tilde`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_Gperp_tilde`
-		std::vector<Real>(flavor_count, INF).data(),
-		// `mean_E_tilde`
-		std::vector<Real>(flavor_count, INF).data()) { }
+	GaussianWwTmdVars const& vars) :
+	GaussianTmdSet(flavor_count, charges, target, GaussianTmdVars(vars)) { }
 
-Real GaussianWwTmdSet::xf1(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xf1(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xf1Tperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xf1Tperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xg1(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xg1(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xg1Tperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xg1Tperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xh1(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xh1(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xh1perp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xh1perp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xh1Lperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xh1Lperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xh1Tperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xh1Tperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real GaussianWwTmdSet::D1(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::D1(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::H1perp(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::H1perp(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
 // Following [2], we take the approach of first integrating over `k_perp_sq`
 // with the Gaussian approximation, and then using Ww-type approximation. This
 // is done to avoid contradictions between these two approximations (see section
 // 4.4 of [2]).
-Real GaussianWwTmdSet::xf1TperpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec GaussianWwTmdSet::xf1TperpM1(Real x, Real Q_sq) const {
 	Real M = mass(target);
-	return mean_f1Tperp[fl]/(2.*M*M)*xf1Tperp(fl, x, Q_sq);
+	return vars.f1Tperp*xf1Tperp(x, Q_sq)/(2*M*M);
 }
-Real GaussianWwTmdSet::xg1TperpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec GaussianWwTmdSet::xg1TperpM1(Real x, Real Q_sq) const {
 	Real M = mass(target);
-	return mean_g1Tperp[fl]/(2.*M*M)*xg1Tperp(fl, x, Q_sq);
+	return vars.g1Tperp*xg1Tperp(x, Q_sq)/(2.*M*M);
 }
-Real GaussianWwTmdSet::xh1perpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec GaussianWwTmdSet::xh1perpM1(Real x, Real Q_sq) const {
 	Real M = mass(target);
-	return mean_h1perp[fl]/(2.*M*M)*xh1perp(fl, x, Q_sq);
+	return vars.h1perp*xh1perp(x, Q_sq)/(2.*M*M);
 }
-Real GaussianWwTmdSet::xh1LperpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec GaussianWwTmdSet::xh1LperpM1(Real x, Real Q_sq) const {
 	Real M = mass(target);
-	return mean_h1Lperp[fl]/(2.*M*M)*xh1Lperp(fl, x, Q_sq);
+	return vars.h1Lperp*xh1Lperp(x, Q_sq)/(2.*M*M);
 }
-Real GaussianWwTmdSet::xh1TperpM1(unsigned fl, Real x, Real Q_sq) const {
+FlavorVec GaussianWwTmdSet::xh1TperpM1(Real x, Real Q_sq) const {
 	Real M = mass(target);
-	return mean_h1Tperp[fl]/(2.*M*M)*xh1Tperp(fl, x, Q_sq);
+	return vars.h1Tperp*xh1Tperp(x, Q_sq)/(2.*M*M);
 }
 
-Real GaussianWwTmdSet::xfT(unsigned fl, Real x, Real Q_sq) const {
-	return -xf1TperpM1(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xfT(Real x, Real Q_sq) const {
+	return -xf1TperpM1(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xfperp(unsigned fl, Real x, Real Q_sq) const {
-	return xf1(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xfperp(Real x, Real Q_sq) const {
+	return xf1(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xfLperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xfLperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xfTperp(unsigned fl, Real x, Real Q_sq) const {
-	return xf1Tperp(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xfTperp(Real x, Real Q_sq) const {
+	return xf1Tperp(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xgT(unsigned fl, Real x, Real Q_sq) const {
-	return xg1TperpM1(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xgT(Real x, Real Q_sq) const {
+	return xg1TperpM1(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xgperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xgperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xgLperp(unsigned fl, Real x, Real Q_sq) const {
-	return xg1(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xgLperp(Real x, Real Q_sq) const {
+	return xg1(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xgTperp(unsigned fl, Real x, Real Q_sq) const {
-	return xg1Tperp(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xgTperp(Real x, Real Q_sq) const {
+	return xg1Tperp(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xh(unsigned fl, Real x, Real Q_sq) const {
-	return -2.*xh1perpM1(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xh(Real x, Real Q_sq) const {
+	return -2.*xh1perpM1(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xhL(unsigned fl, Real x, Real Q_sq) const {
-	return -2.*xh1LperpM1(fl, x, Q_sq)/x;
+FlavorVec GaussianWwTmdSet::xhL(Real x, Real Q_sq) const {
+	return -2.*xh1LperpM1(x, Q_sq)/x;
 }
-Real GaussianWwTmdSet::xhT(unsigned fl, Real x, Real Q_sq) const {
-	return -(xh1(fl, x, Q_sq) + xh1TperpM1(fl, x, Q_sq))/x;
+FlavorVec GaussianWwTmdSet::xhT(Real x, Real Q_sq) const {
+	return -(xh1(x, Q_sq) + xh1TperpM1(x, Q_sq))/x;
 }
-Real GaussianWwTmdSet::xhTperp(unsigned fl, Real x, Real Q_sq) const {
-	return (xh1(fl, x, Q_sq) - xh1TperpM1(fl, x, Q_sq))/x;
+FlavorVec GaussianWwTmdSet::xhTperp(Real x, Real Q_sq) const {
+	return (xh1(x, Q_sq) - xh1TperpM1(x, Q_sq))/x;
 }
-Real GaussianWwTmdSet::xe(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xe(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xeL(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xeL(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xeT(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xeT(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::xeTperp(unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::xeTperp(Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 
-Real GaussianWwTmdSet::Dperp_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::Dperp_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::H_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::H_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::Gperp_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::Gperp_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
-Real GaussianWwTmdSet::E_tilde(part::Hadron, unsigned, Real, Real) const {
-	return 0.;
+FlavorVec GaussianWwTmdSet::E_tilde(part::Hadron, Real, Real) const {
+	return FlavorVec(flavor_count);
 }
 

--- a/src/tmd.cpp
+++ b/src/tmd.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "sidis/constant.hpp"
 #include "sidis/extra/exception.hpp"
 
 using namespace sidis;
@@ -111,38 +112,6 @@ FlavorVec TmdSet::Gperp_tilde(part::Hadron, Real, Real, Real) const {
 FlavorVec TmdSet::E_tilde(part::Hadron, Real, Real, Real) const {
 	return FlavorVec(flavor_count);
 }
-
-GaussianTmdVars::GaussianTmdVars() :
-	f1(1, INF),
-	f1Tperp(1, INF),
-	fT(1, INF),
-	fperp(1, INF),
-	fLperp(1, INF),
-	fTperp(1, INF),
-	g1(1, INF),
-	g1Tperp(1, INF),
-	gT(1, INF),
-	gperp(1, INF),
-	gLperp(1, INF),
-	gTperp(1, INF),
-	h1(1, INF),
-	h1perp(1, INF),
-	h1Lperp(1, INF),
-	h1Tperp(1, INF),
-	h(1, INF),
-	hL(1, INF),
-	hT(1, INF),
-	hTperp(1, INF),
-	e(1, INF),
-	eL(1, INF),
-	eT(1, INF),
-	eTperp(1, INF),
-	D1(1, INF),
-	H1perp(1, INF),
-	Dperp_tilde(1, INF),
-	H_tilde(1, INF),
-	Gperp_tilde(1, INF),
-	E_tilde(1, INF) { }
 
 GaussianTmdVars::GaussianTmdVars(GaussianWwTmdVars const& ww_vars) :
 	// We choose infinity for the width of the structure functions that are to
@@ -534,24 +503,6 @@ FlavorVec WwTmdSet::Gperp_tilde(part::Hadron, Real, Real, Real) const {
 FlavorVec WwTmdSet::E_tilde(part::Hadron, Real, Real, Real) const {
 	return FlavorVec(flavor_count);
 }
-
-GaussianWwTmdVars::GaussianWwTmdVars() :
-	f1(1, INF),
-	f1Tperp(1, INF),
-	fT(1, INF),
-	g1(1, INF),
-	g1Tperp(1, INF),
-	gT(1, INF),
-	h1(1, INF),
-	h1perp(1, INF),
-	h1Lperp(1, INF),
-	h1Tperp(1, INF),
-	h(1, INF),
-	hL(1, INF),
-	hT(1, INF),
-	hTperp(1, INF),
-	D1(1, INF),
-	H1perp(1, INF) { }
 
 // Gaussian and WW-type approximation combined.
 GaussianWwTmdSet::GaussianWwTmdSet(


### PR DESCRIPTION
There are some problems with the TMD interfaces as they are now.

1. They return only a single flavor at a time. For integrating with TMD libraries, it would be more performant to get all of the flavors at once.
2. TMDs are not cached properly, so end up being recalculated many times during cross-sections. This is especially bad for fragmentation functions.

This PR fixes these through a large refactoring of the TMD classes.

- [X] Refactor TMDs to return arrays instead of single flavors.
- [x] Cache TMDs during structure function calculations
- [x] Improve numerical integration of TMDs
- [x] Add more tests, so we can be sure that derived classes like GaussianTmd, GaussianWwTmd, and WwTmd are really doing what they should be.
- [ ] clang-tidy (nevermind, putting this off until develop branch is ready to merge to main)
- [x] Test performance, make sure that it really did improve (it did, by about 20%).